### PR TITLE
Add support for running all components on paths

### DIFF
--- a/charts/theia.cloud-base/Chart.yaml
+++ b/charts/theia.cloud-base/Chart.yaml
@@ -15,10 +15,10 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.7.2
+version: 0.7.3
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "0.7.2"
+appVersion: "0.7.3"

--- a/charts/theia.cloud/Chart.yaml
+++ b/charts/theia.cloud/Chart.yaml
@@ -15,10 +15,10 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.7.2
+version: 0.7.3
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "0.7.2"
+appVersion: "0.7.3"

--- a/charts/theia.cloud/templates/instances-ingress.yaml
+++ b/charts/theia.cloud/templates/instances-ingress.yaml
@@ -5,19 +5,29 @@ metadata:
   namespace: {{ .Release.Namespace }}
   annotations:
     kubernetes.io/ingress.class: nginx
+    {{- if not .Values.hosts.usePaths }}
     cert-manager.io/cluster-issuer: {{ tpl (.Values.ingress.clusterIssuer | toString) . }}
     {{ if .Values.ingress.theiaCloudCommonName }}cert-manager.io/common-name: "Theia.Cloud" {{ end }}
     acme.cert-manager.io/http01-ingress-class: nginx
+    {{- end }}
     nginx.ingress.kubernetes.io/proxy-buffer-size: "8k"
     nginx.ingress.kubernetes.io/rewrite-target: /$2
     nginx.ingress.kubernetes.io/configuration-snippet: |
       proxy_set_header 'X-Forwarded-Uri' $request_uri;
 spec:
-  tls: 
+  tls:
   - hosts:
+  {{- if .Values.hosts.usePaths }}
+    - {{ tpl (.Values.hosts.paths.baseHost | toString) . }}
+  {{- else }}
     - {{ tpl (.Values.hosts.instance | toString) . }}
     secretName: ws-cert-secret
+  {{- end }}
   rules:
+    {{- if .Values.hosts.usePaths }}
+    - host: {{ tpl (.Values.hosts.paths.baseHost | toString) . }}
+    {{- else }}
     - host: {{ tpl (.Values.hosts.instance | toString) . }}
+    {{- end }}
       http:
       

--- a/charts/theia.cloud/templates/landing-page-config-map.yaml
+++ b/charts/theia.cloud/templates/landing-page-config-map.yaml
@@ -13,7 +13,11 @@ data:
       keycloakAuthUrl: "{{ tpl (.Values.keycloak.authUrl | toString) . }}",
       keycloakRealm: "{{ tpl (.Values.keycloak.realm | toString) . }}",
       keycloakClientId: "{{ tpl (.Values.keycloak.clientId | toString) . }}",
+      {{- if .Values.hosts.usePaths }}
+      serviceUrl: "{{ tpl (.Values.hosts.serviceProtocol | toString) . }}://{{ tpl (.Values.hosts.paths.baseHost | toString) . }}/{{ tpl (.Values.hosts.paths.service | toString) . }}",
+      {{- else }}
       serviceUrl: "{{ tpl (.Values.hosts.serviceProtocol | toString) . }}://{{ tpl (.Values.hosts.service | toString) . }}{{ if .Values.hosts.useServicePortInHostname }}:{{ tpl (.Values.hosts.servicePort | toString) . }}{{ end }}",
+      {{- end }}
       appDefinition: "{{ tpl (.Values.landingPage.appDefinition | toString) . }}",
       additionalApps: [
         {{- range $key, $val := .Values.landingPage.additionalApps }}

--- a/charts/theia.cloud/templates/landing-page-ingress.yaml
+++ b/charts/theia.cloud/templates/landing-page-ingress.yaml
@@ -4,16 +4,28 @@ metadata:
   name: landing-page-ingress
   annotations:
     kubernetes.io/ingress.class: nginx
+    {{- if not .Values.hosts.usePaths }}
     cert-manager.io/cluster-issuer: {{ tpl (.Values.ingress.clusterIssuer | toString) . }}
     acme.cert-manager.io/http01-edit-in-place: "true"
+    {{- else }}
+    nginx.ingress.kubernetes.io/rewrite-target: /$2
+    {{- end }}
   namespace: {{ .Release.Namespace }}
 spec:
-  tls: 
+  tls:
   - hosts:
+  {{- if .Values.hosts.usePaths }}
+    - {{ tpl (.Values.hosts.paths.baseHost | toString) . }}
+  {{- else }}
     - {{ tpl (.Values.hosts.landing | toString) . }}
     secretName: landing-page-cert-secret
+  {{- end }}
   rules:
+  {{- if .Values.hosts.usePaths }}
+  - host: {{ tpl (.Values.hosts.paths.baseHost | toString) . }}
+  {{- else }}
   - host: {{ tpl (.Values.hosts.landing | toString) . }}
+  {{- end }}
     http:
       paths:
       - backend:
@@ -21,5 +33,5 @@ spec:
             name: landing-page-service
             port:
               number: 80
-        path: /
+        path: /{{ if .Values.hosts.usePaths }}{{ tpl (.Values.hosts.paths.landing | toString) . }}(/|$)(.*){{ end }}
         pathType: Prefix

--- a/charts/theia.cloud/templates/operator.yaml
+++ b/charts/theia.cloud/templates/operator.yaml
@@ -29,11 +29,20 @@ spec:
           - "--bandwidthLimiter"
           - {{ tpl (.Values.operator.bandwidthLimiter | toString) . }}
           - "--serviceUrl"
+          {{- if .Values.hosts.usePaths }}
+          - {{ tpl (.Values.hosts.serviceProtocol | toString) . }}://{{ tpl (.Values.hosts.paths.baseHost | toString) . }}/{{ tpl (.Values.hosts.paths.service | toString) . }}
+          {{- else}}
           - {{ tpl (.Values.hosts.serviceProtocol | toString) . }}://{{ tpl (.Values.hosts.service | toString) . }}{{ if .Values.hosts.useServicePortInHostname }}:{{ tpl (.Values.hosts.servicePort | toString) . }}{{ end }}
+          {{- end }}
           - "--sessionsPerUser"
           - "{{ tpl (.Values.operator.sessionsPerUser | toString) . }}"
           - "--appId"
           - {{ tpl (.Values.app.id | toString) . }}
+          {{- if .Values.hosts.usePaths }}
+          - "--usePaths"
+          - "--instancesPath"
+          - "{{ tpl (.Values.hosts.paths.instance | toString) . }}"
+          {{- end }}
       {{- if .Values.operator.imagePullSecret }}
       imagePullSecrets:
         - name: {{ tpl (.Values.operator.imagePullSecret | toString) . }}

--- a/charts/theia.cloud/templates/service-ingress.yaml
+++ b/charts/theia.cloud/templates/service-ingress.yaml
@@ -4,16 +4,30 @@ metadata:
   name: service-ingress
   annotations:
     kubernetes.io/ingress.class: nginx
+    {{- if not .Values.hosts.usePaths }}
     cert-manager.io/cluster-issuer: {{ tpl (.Values.ingress.clusterIssuer | toString) . }}
     acme.cert-manager.io/http01-edit-in-place: "true"
+    {{- if .Values.ingress.theiaCloudCommonName }}
+    cert-manager.io/common-name: "Theia.Cloud"
+    {{- end }}
+    {{- end }}
+    nginx.ingress.kubernetes.io/rewrite-target: /service$1
   namespace: {{ .Release.Namespace }}
 spec:
-  tls: 
+  tls:
   - hosts:
+  {{- if .Values.hosts.usePaths }}
+    - {{ tpl (.Values.hosts.paths.baseHost | toString) . }}
+  {{- else }}
     - {{ tpl (.Values.hosts.service | toString) . }}
     secretName: service-cert-secret
+  {{- end }}
   rules:
+  {{- if .Values.hosts.usePaths }}
+  - host: {{ tpl (.Values.hosts.paths.baseHost | toString) . }}
+  {{- else }}
   - host: {{ tpl (.Values.hosts.service | toString) . }}
+  {{- end }}
     http:
       paths:
       - backend:
@@ -21,5 +35,5 @@ spec:
             name: service-service
             port:
               number: {{ tpl (.Values.hosts.servicePort | toString) . }}
-        path: /service
+        path: {{ if .Values.hosts.usePaths }}/{{ tpl (.Values.hosts.paths.service | toString) . }}{{ end }}/service($|(/.*))
         pathType: ImplementationSpecific

--- a/charts/theia.cloud/templates/theia-appdefinition-spec.yaml
+++ b/charts/theia.cloud/templates/theia-appdefinition-spec.yaml
@@ -8,7 +8,11 @@ spec:
   pullSecret: {{ tpl (.Values.image.pullSecret | toString) . }}
   uid: 101
   port: 3000
+  {{- if .Values.hosts.usePaths }}
+  host: {{ tpl (.Values.hosts.paths.baseHost | toString) . }}
+  {{- else }}
   host: {{ tpl (.Values.hosts.instance | toString) . }}
+  {{- end }}
   ingressname: theia-cloud-demo-ws-ingress
   minInstances: 0
   maxInstances: 10

--- a/charts/theia.cloud/values.yaml
+++ b/charts/theia.cloud/values.yaml
@@ -34,6 +34,23 @@ image:
 
 # You may adjust the hostname below.
 hosts:
+
+  # Use paths configures that all services should run on the same host but on different paths.
+  # true uses paths
+  # false uses an explicit host for each service
+  usePaths: false
+
+  # Only needed when usePaths == true. Contains the baseHost and paths for all services
+  paths:
+    # baseHost configures the host for all services when usePaths == true. Otherwise the explicit host definitions of the services are used.
+    baseHost: 192.168.39.173.nip.io
+    # path of the REST service
+    service: servicex
+    # path of the landing page
+    landing: trynow
+    # path for deployed instances
+    instance: instances
+
   # hostname of the REST-API
   service: service.192.168.39.173.nip.io
 

--- a/charts/theia.cloud/valuesMinikubeWithPaths.yaml
+++ b/charts/theia.cloud/valuesMinikubeWithPaths.yaml
@@ -1,0 +1,68 @@
+app:
+  id: asdfghjkl
+  name: Theia Blueprint
+  logo: theiablueprint.svg
+
+issuer:
+  email: mmorlock@example.com
+
+image:
+  name: theiacloud/theia-cloud-demo:0.8.0.MS7
+  pullSecret: ""
+  timeoutStrategy: "FIXEDTIME"
+  timeoutLimit: "30"
+
+hosts:
+   # Use paths configures that all services should run on the same host but on different paths.
+  # true uses paths
+  # false uses an explicit host for each service
+  usePaths: true
+
+  # Only needed when usePaths == true. Contains the baseHost and paths for all services
+  paths:
+    # baseHost configures the host for all services when usePaths == true. Otherwise the explicit host definitions of the services are used.
+    baseHost: 192.168.39.6.nip.io
+    service: servicex
+    landing: trynow
+    instance: instances
+
+  # service: service.192.168.39.6.nip.io
+  serviceProtocol: https
+  # landing: theia.cloud.192.168.39.6.nip.io
+  # instance: ws.192.168.39.6.nip.io
+
+landingPage:
+  image: theia-cloud-try-now-page:paths-1
+  # imagePullSecret: pullsecret
+  appDefinition: "theia-cloud-demo"
+  ephemeralStorage: true
+  # additionalApps: 
+  #   coffee-editor:
+  #     label: "Coffee Editor"
+  #   cdt-cloud-demo:
+  #     label: "CDT.cloud Blueprint"
+
+keycloak:
+  enable: false
+  authUrl: "https://keycloak.192.168.39.6.nip.io/auth/"
+  realm: "TheiaCloud"
+  clientId: "theia-cloud"
+  clientSecret: "publicbutoauth2proxywantsasecret"
+  cookieSecret: "OQINaROshtE9TcZkNAm5Zs2Pv3xaWytBmc5W7sPX7ws="
+
+operator:
+  image: theia-cloud-operator:osw-paths-0
+  # imagePullSecret: pullsecret
+  eagerStart: false
+  cloudProvider: "K8S"
+  bandwidthLimiter: "K8SANNOTATION"
+  sessionsPerUser: "1"
+
+service:
+  image: theiacloud/theia-cloud-service:0.8.0.MS7
+  # imagePullSecret: pullsecret
+
+ingress:
+  instanceName: "theia-cloud-demo-ws-ingress"
+  clusterIssuer: theia-cloud-selfsigned-issuer
+  theiaCloudCommonName: true


### PR DESCRIPTION
Configures the template to enable running theia cloud on subpaths instead of subdomains.