### PR TITLE
Add permissions for app definitions for the service

### DIFF
--- a/charts/theia.cloud-base/templates/service-role.yaml
+++ b/charts/theia.cloud-base/templates/service-role.yaml
@@ -10,6 +10,7 @@ rules:
       - ""
       - theia.cloud
     resources:
+      - appdefinitions
       - sessions
       - workspaces
     verbs: ["list", "create", "watch", "get", "patch", "delete"]


### PR DESCRIPTION
This is required so the service can check whether an app definition exists before creating a session for it.