### PR TITLE
Make containers' imagePullPolicy configurable via helm chart

### DIFF
--- a/charts/theia.cloud-base/Chart.yaml
+++ b/charts/theia.cloud-base/Chart.yaml
@@ -15,10 +15,10 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.7.7
+version: 0.7.8
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "0.7.7"
+appVersion: "0.7.8"

--- a/charts/theia.cloud/Chart.yaml
+++ b/charts/theia.cloud/Chart.yaml
@@ -15,10 +15,10 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.7.7
+version: 0.7.8
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "0.7.7"
+appVersion: "0.7.8"

--- a/charts/theia.cloud/crds/appdefinition-spec-resource.yaml
+++ b/charts/theia.cloud/crds/appdefinition-spec-resource.yaml
@@ -25,6 +25,9 @@ spec:
                   type: string
                 image:
                   type: string
+                imagePullPolicy:
+                  type: string
+                  enum: ["Always", "IfNotPresent", "Never"]
                 pullSecret:
                   type: string
                 uid:

--- a/charts/theia.cloud/templates/landing-page.yaml
+++ b/charts/theia.cloud/templates/landing-page.yaml
@@ -19,7 +19,7 @@ spec:
       containers:
         - name: landing-page-container
           image: {{ tpl (.Values.landingPage.image | toString) . }}
-          imagePullPolicy: IfNotPresent
+          imagePullPolicy: {{ if .Values.landingPage.imagePullPolicy }}{{ tpl (.Values.landingPage.imagePullPolicy | toString) . }}{{ else }}{{ tpl (.Values.imagePullPolicy | toString) . }}{{ end }}
           ports:
             - name: http
               containerPort: 80

--- a/charts/theia.cloud/templates/operator.yaml
+++ b/charts/theia.cloud/templates/operator.yaml
@@ -21,7 +21,7 @@ spec:
       containers:
       - name: operator-container
         image: {{ tpl (.Values.operator.image | toString) . }}
-        imagePullPolicy: IfNotPresent
+        imagePullPolicy: {{ if .Values.operator.imagePullPolicy }}{{ tpl (.Values.operator.imagePullPolicy | toString) . }}{{ else }}{{ tpl (.Values.imagePullPolicy | toString) . }}{{ end }}
         args:
           {{ if .Values.keycloak.enable }}- "--keycloak"{{ end }}
           {{ if .Values.operator.eagerStart }}- "--eagerStart"{{ end }}

--- a/charts/theia.cloud/templates/service.yaml
+++ b/charts/theia.cloud/templates/service.yaml
@@ -21,6 +21,7 @@ spec:
       containers:
       - name: service-container
         image: {{ tpl (.Values.service.image | toString) . }}
+        imagePullPolicy: {{ if .Values.service.imagePullPolicy }}{{ tpl (.Values.service.imagePullPolicy | toString) . }}{{ else }}{{ tpl (.Values.imagePullPolicy | toString) . }}{{ end }}
         ports:
         - name: http
           containerPort: {{ tpl (.Values.hosts.servicePort | toString) . }}

--- a/charts/theia.cloud/templates/theia-appdefinition-spec.yaml
+++ b/charts/theia.cloud/templates/theia-appdefinition-spec.yaml
@@ -5,6 +5,7 @@ metadata:
 spec:
   name: theia-cloud-demo
   image: {{ tpl (.Values.image.name | toString) . }}
+  imagePullPolicy: {{ if .Values.image.imagePullPolicy }}{{ tpl (.Values.image.imagePullPolicy | toString) . }}{{ else }}{{ tpl (.Values.imagePullPolicy | toString) . }}{{ end }}
   pullSecret: {{ tpl (.Values.image.pullSecret | toString) . }}
   uid: 101
   port: 3000

--- a/charts/theia.cloud/values.yaml
+++ b/charts/theia.cloud/values.yaml
@@ -1,3 +1,11 @@
+# The default imagePullPolicy for containers of theia cloud.
+# Can be overridden for individual components by specifying the imagePullPolicy variable there.
+# Possible values:
+# - Always
+# - IfNotPresent
+# - Never
+imagePullPolicy: Always
+
 # General information about the deployed app
 app:
   # The app id which is used in the communication between website and REST-API
@@ -19,6 +27,10 @@ issuer:
 image:
   # The name of docker image to be used
   name: theiacloud/theia-cloud-demo:0.8.0.MS7
+
+  # Optional: Override the imagePullPolicy for the main application's docker image.
+  # If this is omitted or empty, the root at .Values.imagePullPolicy is used.
+  # imagePullPolicy: IfNotPresent
 
   # the image pull secret. Leave empty if registry is public
   pullSecret: ""
@@ -74,6 +86,10 @@ landingPage:
   # the landing page image to use
   image: theiacloud/theia-cloud-landing-page:0.8.0.MS7
 
+  # Optional: Override the imagePullPolicy for the landing page's docker image.
+  # If this is omitted or empty, the root at .Values.imagePullPolicy is used.
+  # imagePullPolicy: IfNotPresent
+
   # Optional: the image pull secret
   imagePullSecret: pullsecret
 
@@ -124,6 +140,10 @@ operator:
   # The operator image
   image: theiacloud/theia-cloud-operator:0.8.0.MS7
 
+  # Optional: Override the imagePullPolicy for the operator's docker image.
+  # If this is omitted or empty, the root at .Values.imagePullPolicy is used.
+  # imagePullPolicy: IfNotPresent
+
   # Optional: the image pull secret
   imagePullSecret: pullsecret
 
@@ -153,6 +173,10 @@ operator:
 service:
   # The image to use
   image: theiacloud/theia-cloud-service:0.8.0.MS7
+
+  # Optional: Override the imagePullPolicy for the service's docker image.
+  # If this is omitted or empty, the root at .Values.imagePullPolicy is used.
+  # imagePullPolicy: IfNotPresent
 
   # Optional: the image pull secret
   imagePullSecret: pullsecret

--- a/charts/theia.cloud/valuesCDT.yaml
+++ b/charts/theia.cloud/valuesCDT.yaml
@@ -1,3 +1,5 @@
+imagePullPolicy: Always
+
 app:
   id: asdfghjkl
   name: CDT.cloud Blueprint

--- a/charts/theia.cloud/valuesGKETryNow.yaml
+++ b/charts/theia.cloud/valuesGKETryNow.yaml
@@ -1,3 +1,5 @@
+imagePullPolicy: Always
+
 app:
   id: asdfghjkl
   name: Theia Blueprint

--- a/charts/theia.cloud/valuesGKETryNowCDT.yaml
+++ b/charts/theia.cloud/valuesGKETryNowCDT.yaml
@@ -1,3 +1,5 @@
+imagePullPolicy: Always
+
 app:
   id: asdfghjkl
   name: CDT.cloud Blueprint

--- a/charts/theia.cloud/valuesMinikube.yaml
+++ b/charts/theia.cloud/valuesMinikube.yaml
@@ -1,3 +1,5 @@
+imagePullPolicy: IfNotPresent
+
 app:
   id: asdfghjkl
   name: Theia Blueprint

--- a/charts/theia.cloud/valuesMinikubeCDT.yaml
+++ b/charts/theia.cloud/valuesMinikubeCDT.yaml
@@ -1,3 +1,5 @@
+imagePullPolicy: IfNotPresent
+
 app:
   id: asdfghjkl
   name: CDT.cloud Blueprint

--- a/charts/theia.cloud/valuesMinikubeWithPaths.yaml
+++ b/charts/theia.cloud/valuesMinikubeWithPaths.yaml
@@ -1,3 +1,5 @@
+imagePullPolicy: IfNotPresent
+
 app:
   id: asdfghjkl
   name: Theia Blueprint


### PR DESCRIPTION
Make containers' imagePullPolicy configurable via helm chart

- Add root level value `imagePullPolicy` and a value for each component
- Use component-specific value if available, otherwise fall back to root level property
- Extend templates for this
- Extend app definition CRD to store the pull policy
- Add root level property to all values files. Use Always for online and IfNotPresent for Minikube

Part of https://github.com/eclipsesource/theia-cloud/issues/109

Contributed on behalf of STMicroelectronics

**Note:** For the image policy to be applied to session pods, an update of the operator is required. This is implemented here: https://github.com/eclipsesource/theia-cloud/pull/116