### PR TITLE
Adapt service role to remove write access on pods

### DIFF
--- a/charts/theia.cloud-base/templates/service-role.yaml
+++ b/charts/theia.cloud-base/templates/service-role.yaml
@@ -9,12 +9,17 @@ rules:
     apiGroups:
       - ""
       - theia.cloud
-      - metrics.k8s.io
     resources:
       - appdefinitions
       - sessions
       - workspaces
-      - pods
     verbs: ["list", "create", "watch", "get", "patch", "delete"]
+  -
+    apiGroups:
+      - ""
+      - metrics.k8s.io
+    resources:
+      - pods
+    verbs: ["list", "get", "watch"]
 
 {{- end }}


### PR DESCRIPTION
Split the rules for custom resource and metrics access.
Now, the service can no longer create, modify or delete pods.

Related to https://github.com/eclipsesource/theia-cloud/issues/120

Contributed on behalf of STMicroelectronics and CEA

Signed-off-by: Lucas Koehler <lkoehler@eclipsesource.com>