### PR TITLE
Fix ingresses to handle missing trailing slashes

### DIFF
--- a/charts/theia.cloud/templates/landing-page-ingress.yaml
+++ b/charts/theia.cloud/templates/landing-page-ingress.yaml
@@ -9,6 +9,10 @@ metadata:
     acme.cert-manager.io/http01-edit-in-place: "true"
     {{- else }}
     nginx.ingress.kubernetes.io/rewrite-target: /$2
+    # Rewrite all URLs not ending with a segment containing . or ? with a trailing slash
+    # This is necessary to correctly resolve relative paths (e.g. for css files) from the landing page.
+    nginx.ingress.kubernetes.io/configuration-snippet: |
+      rewrite ^([^.?]*[^/])$ $1/ redirect;
     {{- end }}
   namespace: {{ .Release.Namespace }}
 spec:


### PR DESCRIPTION
- Fix landing page ingress to work for paths without trailing slash (https://github.com/eclipsesource/theia-cloud/issues/124)  
- ~Fix workspace ingress to work direct links without trailing slash (https://github.com/eclipsesource/theia-cloud/issues/23)~ -> Removed because current version results in redirect loop whe using keycloak

Contributed on behalf of STMicroelectronics and CEA