### PR TITLE
Add operator values to configure storage class and amount

### DIFF
--- a/charts/theia.cloud/templates/operator.yaml
+++ b/charts/theia.cloud/templates/operator.yaml
@@ -46,6 +46,10 @@ spec:
           - "--instancesPath"
           - "{{ tpl (.Values.hosts.paths.instance | toString) . }}"
           {{- end }}
+          - "--storageClassName"
+          - "{{ tpl (.Values.operator.storageClassName | toString) . }}"
+          - "--requestedStorage"
+          - "{{ tpl (.Values.operator.requestedStorage | toString) . }}"
           {{- if .Values.monitor.enable }}
           - "--enableMonitor"
           {{- if .Values.monitor.activityTracker.enable }}

--- a/charts/theia.cloud/values.yaml
+++ b/charts/theia.cloud/values.yaml
@@ -154,9 +154,9 @@ operator:
   # Currently only false is fully supported.
   eagerStart: false
 
-  # Select your cloude provider. Possible values:
-  # - K8S   Plain Kubernetes
-  # - GKE   Google Kubernetes Engine
+  # Select your cloud provider. Possible values:
+  # - K8S      Plain Kubernetes
+  # - MINIKUBE Local deployment on Minikube
   cloudProvider: "K8S"
 
   # Whether Theia Cloud shall limit network speed. This might not be fully supported
@@ -171,6 +171,16 @@ operator:
 
   # Set the number of active sessions a single user can launch
   sessionsPerUser: "1"
+
+  # The name of the storage class for persistent volume claims for workspaces.
+  # This storage class must be present on the cluster.
+  # Most cloud providers offer a default storage class without additional configuration.
+  storageClassName: "default"
+
+  # The amount of requested storage for each persistent volume claim (PVC) for workspaces.
+  # This is directly passed to created PVCs and must be a valid Kubernetes quantity.
+  # See https://kubernetes.io/docs/reference/kubernetes-api/common-definitions/quantity/
+  requestedStorage: "250Mi"
 
 # Values of the Theia.cloud REST service
 service:


### PR DESCRIPTION
- Add values to configure persistent workspace volumes:
  - `operator.storageClassName` for the storage class available on the cluster
  - `operator.requestedStorage` for the amount of requested storage space
- Adapt doc for new MINIKUBE cloud provider and removed GKE

Part of https://github.com/eclipsesource/theia-cloud/issues/92

Contributed on behalf of STMicroelectronics

See https://github.com/eclipsesource/theia-cloud/pull/144 for the code changes