### PR TITLE
Fix ACME challenges for ingresses with path rewrites

### DIFF
--- a/charts/theia.cloud/templates/landing-page-ingress.yaml
+++ b/charts/theia.cloud/templates/landing-page-ingress.yaml
@@ -6,7 +6,6 @@ metadata:
     kubernetes.io/ingress.class: nginx
     {{- if not .Values.hosts.usePaths }}
     cert-manager.io/cluster-issuer: {{ tpl (.Values.ingress.clusterIssuer | toString) . }}
-    acme.cert-manager.io/http01-edit-in-place: "true"
     {{- else }}
     nginx.ingress.kubernetes.io/rewrite-target: /$2
     # Rewrite all URLs not ending with a segment containing . or ? with a trailing slash

--- a/charts/theia.cloud/templates/service-ingress.yaml
+++ b/charts/theia.cloud/templates/service-ingress.yaml
@@ -6,7 +6,6 @@ metadata:
     kubernetes.io/ingress.class: nginx
     {{- if not .Values.hosts.usePaths }}
     cert-manager.io/cluster-issuer: {{ tpl (.Values.ingress.clusterIssuer | toString) . }}
-    acme.cert-manager.io/http01-edit-in-place: "true"
     {{- if .Values.ingress.theiaCloudCommonName }}
     cert-manager.io/common-name: "Theia.Cloud"
     {{- end }}


### PR DESCRIPTION
No longer let cert-manager edit ingresses in place to handle ACME challenges because this does not work with path rewrites.

Contributed on behalf of STMicroelectronics