### PR TITLE
Add hosts.tls flag to values

### DIFF
--- a/charts/theia.cloud/templates/instances-ingress-path-based.yaml
+++ b/charts/theia.cloud/templates/instances-ingress-path-based.yaml
@@ -6,14 +6,19 @@ metadata:
   namespace: {{ .Release.Namespace }}
   annotations:
     kubernetes.io/ingress.class: nginx
+    {{- if not .Values.hosts.tls }}
+    nginx.ingress.kubernetes.io/ssl-redirect: "false"
+    {{- end }}
     nginx.ingress.kubernetes.io/proxy-buffer-size: "128k"
     nginx.ingress.kubernetes.io/rewrite-target: /$2
     nginx.ingress.kubernetes.io/configuration-snippet: |
       proxy_set_header 'X-Forwarded-Uri' $request_uri;
 spec:
+  {{- if .Values.hosts.tls }}
   tls:
   - hosts:
     - {{ tpl (.Values.hosts.paths.baseHost | toString) . }}
+  {{- end }}
   rules:
     - host: {{ tpl (.Values.hosts.paths.baseHost | toString) . }}
       http:

--- a/charts/theia.cloud/templates/instances-ingress-path-based.yaml
+++ b/charts/theia.cloud/templates/instances-ingress-path-based.yaml
@@ -1,4 +1,4 @@
-{{- if not .Values.hosts.usePaths }}
+{{- if .Values.hosts.usePaths }}
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
@@ -6,9 +6,6 @@ metadata:
   namespace: {{ .Release.Namespace }}
   annotations:
     kubernetes.io/ingress.class: nginx
-    cert-manager.io/cluster-issuer: {{ tpl (.Values.ingress.clusterIssuer | toString) . }}
-    {{ if .Values.ingress.theiaCloudCommonName }}cert-manager.io/common-name: "Theia.Cloud" {{ end }}
-    acme.cert-manager.io/http01-ingress-class: nginx
     nginx.ingress.kubernetes.io/proxy-buffer-size: "128k"
     nginx.ingress.kubernetes.io/rewrite-target: /$2
     nginx.ingress.kubernetes.io/configuration-snippet: |
@@ -16,9 +13,8 @@ metadata:
 spec:
   tls:
   - hosts:
-    - {{ tpl (.Values.hosts.instance | toString) . }}
-    secretName: ws-cert-secret
+    - {{ tpl (.Values.hosts.paths.baseHost | toString) . }}
   rules:
-    - host: {{ tpl (.Values.hosts.instance | toString) . }}
+    - host: {{ tpl (.Values.hosts.paths.baseHost | toString) . }}
       http:
 {{- end }}

--- a/charts/theia.cloud/templates/instances-ingress.yaml
+++ b/charts/theia.cloud/templates/instances-ingress.yaml
@@ -6,18 +6,23 @@ metadata:
   namespace: {{ .Release.Namespace }}
   annotations:
     kubernetes.io/ingress.class: nginx
+    {{- if not .Values.hosts.tls }}
+    nginx.ingress.kubernetes.io/ssl-redirect: "false"
+    {{- end }}
     cert-manager.io/cluster-issuer: {{ tpl (.Values.ingress.clusterIssuer | toString) . }}
-    {{ if .Values.ingress.theiaCloudCommonName }}cert-manager.io/common-name: "Theia.Cloud" {{ end }}
+    {{- if .Values.ingress.theiaCloudCommonName }}cert-manager.io/common-name: "Theia.Cloud" {{- end }}
     acme.cert-manager.io/http01-ingress-class: nginx
     nginx.ingress.kubernetes.io/proxy-buffer-size: "128k"
     nginx.ingress.kubernetes.io/rewrite-target: /$2
     nginx.ingress.kubernetes.io/configuration-snippet: |
       proxy_set_header 'X-Forwarded-Uri' $request_uri;
 spec:
+  {{- if .Values.hosts.tls }}
   tls:
   - hosts:
     - {{ tpl (.Values.hosts.instance | toString) . }}
     secretName: ws-cert-secret
+  {{- end }}
   rules:
     - host: {{ tpl (.Values.hosts.instance | toString) . }}
       http:

--- a/charts/theia.cloud/templates/landing-page-ingress-path-based.yaml
+++ b/charts/theia.cloud/templates/landing-page-ingress-path-based.yaml
@@ -5,6 +5,9 @@ metadata:
   name: landing-page-ingress
   annotations:
     kubernetes.io/ingress.class: nginx
+    {{- if not .Values.hosts.tls }}
+    nginx.ingress.kubernetes.io/ssl-redirect: "false"
+    {{- end }}
     {{- if .Values.hosts.paths.landing }}
     nginx.ingress.kubernetes.io/rewrite-target: /$2
     {{- end }}
@@ -14,9 +17,11 @@ metadata:
       rewrite ^([^.?]*[^/])$ $1/ redirect;
   namespace: {{ .Release.Namespace }}
 spec:
+  {{- if .Values.hosts.tls }}
   tls:
   - hosts:
     - {{ tpl (.Values.hosts.paths.baseHost | toString) . }}
+  {{- end }}
   rules:
   - host: {{ tpl (.Values.hosts.paths.baseHost | toString) . }}
     http:

--- a/charts/theia.cloud/templates/landing-page-ingress-path-based.yaml
+++ b/charts/theia.cloud/templates/landing-page-ingress-path-based.yaml
@@ -1,0 +1,31 @@
+{{- if .Values.hosts.usePaths }}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: landing-page-ingress
+  annotations:
+    kubernetes.io/ingress.class: nginx
+    {{- if .Values.hosts.paths.landing }}
+    nginx.ingress.kubernetes.io/rewrite-target: /$2
+    {{- end }}
+    # Rewrite all URLs not ending with a segment containing . or ? with a trailing slash
+    # This is necessary to correctly resolve relative paths (e.g. for css files) from the landing page.
+    nginx.ingress.kubernetes.io/configuration-snippet: |
+      rewrite ^([^.?]*[^/])$ $1/ redirect;
+  namespace: {{ .Release.Namespace }}
+spec:
+  tls:
+  - hosts:
+    - {{ tpl (.Values.hosts.paths.baseHost | toString) . }}
+  rules:
+  - host: {{ tpl (.Values.hosts.paths.baseHost | toString) . }}
+    http:
+      paths:
+      - backend:
+          service:
+            name: landing-page-service
+            port:
+              number: 80
+        path: /{{ if .Values.hosts.paths.landing }}{{ tpl (.Values.hosts.paths.landing | toString) . }}(/|$)(.*){{ end }}
+        pathType: Prefix
+{{- end }}

--- a/charts/theia.cloud/templates/landing-page-ingress.yaml
+++ b/charts/theia.cloud/templates/landing-page-ingress.yaml
@@ -1,34 +1,19 @@
+{{- if not .Values.hosts.usePaths }}
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: landing-page-ingress
   annotations:
     kubernetes.io/ingress.class: nginx
-    {{- if not .Values.hosts.usePaths }}
     cert-manager.io/cluster-issuer: {{ tpl (.Values.ingress.clusterIssuer | toString) . }}
-    {{- else }}
-    nginx.ingress.kubernetes.io/rewrite-target: /$2
-    # Rewrite all URLs not ending with a segment containing . or ? with a trailing slash
-    # This is necessary to correctly resolve relative paths (e.g. for css files) from the landing page.
-    nginx.ingress.kubernetes.io/configuration-snippet: |
-      rewrite ^([^.?]*[^/])$ $1/ redirect;
-    {{- end }}
   namespace: {{ .Release.Namespace }}
 spec:
   tls:
   - hosts:
-  {{- if .Values.hosts.usePaths }}
-    - {{ tpl (.Values.hosts.paths.baseHost | toString) . }}
-  {{- else }}
     - {{ tpl (.Values.hosts.landing | toString) . }}
     secretName: landing-page-cert-secret
-  {{- end }}
   rules:
-  {{- if .Values.hosts.usePaths }}
-  - host: {{ tpl (.Values.hosts.paths.baseHost | toString) . }}
-  {{- else }}
   - host: {{ tpl (.Values.hosts.landing | toString) . }}
-  {{- end }}
     http:
       paths:
       - backend:
@@ -36,5 +21,6 @@ spec:
             name: landing-page-service
             port:
               number: 80
-        path: /{{ if .Values.hosts.usePaths }}{{ tpl (.Values.hosts.paths.landing | toString) . }}(/|$)(.*){{ end }}
+        path: /
         pathType: Prefix
+{{- end }}

--- a/charts/theia.cloud/templates/landing-page-ingress.yaml
+++ b/charts/theia.cloud/templates/landing-page-ingress.yaml
@@ -5,13 +5,18 @@ metadata:
   name: landing-page-ingress
   annotations:
     kubernetes.io/ingress.class: nginx
+    {{- if not .Values.hosts.tls }}
+    nginx.ingress.kubernetes.io/ssl-redirect: "false"
+    {{- end }}
     cert-manager.io/cluster-issuer: {{ tpl (.Values.ingress.clusterIssuer | toString) . }}
   namespace: {{ .Release.Namespace }}
 spec:
+  {{- if .Values.hosts.tls }}
   tls:
   - hosts:
     - {{ tpl (.Values.hosts.landing | toString) . }}
     secretName: landing-page-cert-secret
+  {{- end }}
   rules:
   - host: {{ tpl (.Values.hosts.landing | toString) . }}
     http:

--- a/charts/theia.cloud/templates/service-ingress-path-based.yaml
+++ b/charts/theia.cloud/templates/service-ingress-path-based.yaml
@@ -1,23 +1,18 @@
-{{- if not .Values.hosts.usePaths }}
+{{- if .Values.hosts.usePaths }}
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: service-ingress
   annotations:
     kubernetes.io/ingress.class: nginx
-    cert-manager.io/cluster-issuer: {{ tpl (.Values.ingress.clusterIssuer | toString) . }}
-    {{- if .Values.ingress.theiaCloudCommonName }}
-    cert-manager.io/common-name: "Theia.Cloud"
-    {{- end }}
     nginx.ingress.kubernetes.io/rewrite-target: /service$1
   namespace: {{ .Release.Namespace }}
 spec:
   tls:
   - hosts:
-    - {{ tpl (.Values.hosts.service | toString) . }}
-    secretName: service-cert-secret
+    - {{ tpl (.Values.hosts.paths.baseHost | toString) . }}
   rules:
-  - host: {{ tpl (.Values.hosts.service | toString) . }}
+  - host: {{ tpl (.Values.hosts.paths.baseHost | toString) . }}
     http:
       paths:
       - backend:
@@ -25,6 +20,6 @@ spec:
             name: service-service
             port:
               number: {{ tpl (.Values.hosts.servicePort | toString) . }}
-        path: /service($|(/.*))
+        path: /{{ tpl (.Values.hosts.paths.service | toString) . }}/service($|(/.*))
         pathType: ImplementationSpecific
 {{- end }}

--- a/charts/theia.cloud/templates/service-ingress-path-based.yaml
+++ b/charts/theia.cloud/templates/service-ingress-path-based.yaml
@@ -5,12 +5,17 @@ metadata:
   name: service-ingress
   annotations:
     kubernetes.io/ingress.class: nginx
+    {{- if not .Values.hosts.tls }}
+    nginx.ingress.kubernetes.io/ssl-redirect: "false"
+    {{- end }}
     nginx.ingress.kubernetes.io/rewrite-target: /service$1
   namespace: {{ .Release.Namespace }}
 spec:
+  {{- if .Values.hosts.tls }}
   tls:
   - hosts:
     - {{ tpl (.Values.hosts.paths.baseHost | toString) . }}
+  {{- end }}
   rules:
   - host: {{ tpl (.Values.hosts.paths.baseHost | toString) . }}
     http:

--- a/charts/theia.cloud/templates/service-ingress.yaml
+++ b/charts/theia.cloud/templates/service-ingress.yaml
@@ -5,6 +5,9 @@ metadata:
   name: service-ingress
   annotations:
     kubernetes.io/ingress.class: nginx
+    {{- if not .Values.hosts.tls }}
+    nginx.ingress.kubernetes.io/ssl-redirect: "false"
+    {{- end }}
     cert-manager.io/cluster-issuer: {{ tpl (.Values.ingress.clusterIssuer | toString) . }}
     {{- if .Values.ingress.theiaCloudCommonName }}
     cert-manager.io/common-name: "Theia.Cloud"
@@ -12,10 +15,12 @@ metadata:
     nginx.ingress.kubernetes.io/rewrite-target: /service$1
   namespace: {{ .Release.Namespace }}
 spec:
+  {{- if .Values.hosts.tls }}
   tls:
   - hosts:
     - {{ tpl (.Values.hosts.service | toString) . }}
     secretName: service-cert-secret
+  {{- end }}
   rules:
   - host: {{ tpl (.Values.hosts.service | toString) . }}
     http:

--- a/charts/theia.cloud/values.yaml
+++ b/charts/theia.cloud/values.yaml
@@ -50,6 +50,10 @@ hosts:
   # false uses an explicit host for each service
   usePaths: false
 
+  # Does Theia Cloud expect TLS connections (true)
+  # or is TLS terminated outside of Theia Cloud (e.g. via a Load Balancer) (false)
+  tls: true
+
   # Only needed when usePaths == true. Contains the baseHost and paths for all services
   paths:
     # baseHost configures the host for all services when usePaths == true. Otherwise the explicit host definitions of the services are used.


### PR DESCRIPTION
If this is set to false (true is the default) the ingresses won't expect
(and terminate) a TLS connection.
This way TLS can be terminated outside of Theia Cloud, if needed.
Additionally the ingresses won't redirect to ssl to avoid circles.

On top of that i split the ingress templates for path-based and subdomain-based for better readability.