### PR TITLE
Render TLS certificates to Ingress when the service REST-API is HTTPS

### DIFF
--- a/charts/theia.cloud/templates/service-ingress.yaml
+++ b/charts/theia.cloud/templates/service-ingress.yaml
@@ -13,13 +13,15 @@ metadata:
     nginx.ingress.kubernetes.io/rewrite-target: /service$1
   namespace: {{ .Release.Namespace }}
 spec:
+  {{- if eq .Values.hosts.serviceProtocol "https" }}
   tls:
   - hosts:
-  {{- if .Values.hosts.usePaths }}
+    {{- if .Values.hosts.usePaths }}
     - {{ tpl (.Values.hosts.paths.baseHost | toString) . }}
-  {{- else }}
+    {{- else }}
     - {{ tpl (.Values.hosts.service | toString) . }}
     secretName: service-cert-secret
+    {{- end }}
   {{- end }}
   rules:
   {{- if .Values.hosts.usePaths }}


### PR DESCRIPTION
If the `.hosts.serviceProtocol` field is `http` in values.yaml, the TLS certificate should not be configured in the service ingress.
