### PR TITLE
Allow configuration of proxy-body size for instances-ingress

### DIFF
--- a/charts/theia.cloud/Chart.yaml
+++ b/charts/theia.cloud/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.8.0
+version: 0.8.1-v001
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/theia.cloud/templates/instances-ingress-path-based.yaml
+++ b/charts/theia.cloud/templates/instances-ingress-path-based.yaml
@@ -13,6 +13,7 @@ metadata:
     nginx.ingress.kubernetes.io/rewrite-target: /$2
     nginx.ingress.kubernetes.io/configuration-snippet: |
       proxy_set_header 'X-Forwarded-Uri' $request_uri;
+    nginx.ingress.kubernetes.io/proxy-body-size: {{ tpl (.Values.ingress.proxyBodySize | toString) . }}
 spec:
   {{- if .Values.hosts.tls }}
   tls:

--- a/charts/theia.cloud/templates/instances-ingress.yaml
+++ b/charts/theia.cloud/templates/instances-ingress.yaml
@@ -18,6 +18,7 @@ metadata:
     nginx.ingress.kubernetes.io/rewrite-target: /$2
     nginx.ingress.kubernetes.io/configuration-snippet: |
       proxy_set_header 'X-Forwarded-Uri' $request_uri;
+    nginx.ingress.kubernetes.io/proxy-body-size: {{ tpl (.Values.ingress.proxyBodySize | toString) . }}
 spec:
   {{- if .Values.hosts.tls }}
   tls:

--- a/charts/theia.cloud/values.yaml
+++ b/charts/theia.cloud/values.yaml
@@ -212,6 +212,10 @@ ingress:
   # common-name
   theiaCloudCommonName: false
 
+  # Sets the maximum allowed size of the client request body inside the application (e.g. file uploads in Theia).
+  # Defaults to 1m. Setting size to 0 disables checking of client request body size.
+  proxyBodySize: 1m
+
 operatorrole:
   name: operator-api-access
 


### PR DESCRIPTION
Define the `proxy-body-size` value for instances-ingress and allow to customize it via the values file.
The `proxy-body-size` resembles the maximum allowed size of the client request body.
(e.g. relevant for file-uploads in the Theia application)