### PR TITLE
Remove hostname from appdefinitions

### DIFF
--- a/charts/theia.cloud/Chart.yaml
+++ b/charts/theia.cloud/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.8.1-v001
+version: 0.8.1-v002
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/theia.cloud/crds/appdefinition-spec-resource.yaml
+++ b/charts/theia.cloud/crds/appdefinition-spec-resource.yaml
@@ -11,9 +11,71 @@ spec:
     singular: appdefinition
   scope: Namespaced
   versions:
-    - name: v5beta
+    - name: v6beta
       served: true
       storage: true
+      schema:
+        openAPIV3Schema:
+          type: object
+          properties:
+            spec:
+              type: object
+              properties:
+                name:
+                  type: string
+                image:
+                  type: string
+                imagePullPolicy:
+                  type: string
+                  enum: ["Always", "IfNotPresent", "Never"]
+                pullSecret:
+                  type: string
+                uid:
+                  type: integer
+                port:
+                  type: integer
+                ingressname:
+                  type: string
+                minInstances:
+                  type: integer
+                maxInstances:
+                  type: integer
+                timeout:
+                  type: object
+                  properties:
+                    strategy:
+                      type: string
+                    limit:
+                      type: integer
+                requestsMemory:
+                  type: string
+                requestsCpu:
+                  type: string
+                limitsMemory:
+                  type: string
+                limitsCpu:
+                  type: string
+                downlinkLimit:
+                  type: integer
+                uplinkLimit:
+                  type: integer
+                mountPath:
+                  type: string
+                monitor:
+                  type: object
+                  properties:
+                    port:
+                      type: integer
+                    activityTracker:
+                      type: object
+                      properties:
+                        timeoutAfter:
+                          type: integer
+                        notifyAfter:
+                          type: integer
+    - name: v5beta
+      served: true
+      storage: false
       schema:
         openAPIV3Schema:
           type: object

--- a/charts/theia.cloud/templates/operator.yaml
+++ b/charts/theia.cloud/templates/operator.yaml
@@ -50,9 +50,14 @@ spec:
           - "--appId"
           - {{ tpl (.Values.app.id | toString) . }}
           {{- if .Values.hosts.usePaths }}
+          - "--instancesHost"
+          - "{{ tpl (.Values.hosts.paths.baseHost | toString) . }}"
           - "--usePaths"
           - "--instancesPath"
           - "{{ tpl (.Values.hosts.paths.instance | toString) . }}"
+          {{- else }}
+          - "--instancesHost"
+          - "{{ tpl (.Values.hosts.instance | toString) . }}"
           {{- end }}
           - "--storageClassName"
           - "{{ tpl (.Values.operator.storageClassName | toString) . }}"

--- a/charts/theia.cloud/templates/theia-appdefinition-spec.yaml
+++ b/charts/theia.cloud/templates/theia-appdefinition-spec.yaml
@@ -1,4 +1,4 @@
-apiVersion: theia.cloud/v5beta
+apiVersion: theia.cloud/v6beta
 kind: AppDefinition
 metadata:
   name: theia-cloud-demo
@@ -9,11 +9,6 @@ spec:
   pullSecret: {{ tpl (.Values.image.pullSecret | toString) . }}
   uid: 101
   port: 3000
-  {{- if .Values.hosts.usePaths }}
-  host: {{ tpl (.Values.hosts.paths.baseHost | toString) . }}
-  {{- else }}
-  host: {{ tpl (.Values.hosts.instance | toString) . }}
-  {{- end }}
   ingressname: {{ tpl (.Values.ingress.instanceName | toString) . }}
   minInstances: 0
   maxInstances: 10


### PR DESCRIPTION
**NOTE:** The charts version and app version might need adaption after the [main PR](https://github.com/eclipsesource/theia-cloud/pull/208) was merged
- Add version v6beta of AppDefinition CRD that removes the host property
- Hand in hostname to operator as command line argument

Part of eclipsesource/theia-cloud#189

Contributed on behalf of STMicroelectronics
Signed-off-by: Lucas Koehler <lkoehler@eclipsesource.com>