### PR TITLE
Enable providing an external svg image for landing pages

### DIFF
--- a/charts/theia.cloud/Chart.yaml
+++ b/charts/theia.cloud/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.8.1-v003
+version: 0.8.1-v004
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/theia.cloud/templates/landing-page-config-map.yaml
+++ b/charts/theia.cloud/templates/landing-page-config-map.yaml
@@ -29,6 +29,10 @@ data:
       ],
     };
 binaryData:
-  {{ range $path, $bytes := .Files.Glob (printf "%s" .Values.app.logo)}}
+  {{- if .Values.app.logoData }}
+  {{ print "logo.svg: "}}{{ .Values.app.logoData }}
+  {{- else }}
+  {{- range $path, $bytes := .Files.Glob (printf "%s" .Values.app.logo)}}
   {{ print "logo.svg: "}}{{ $.Files.Get $path | b64enc }}
   {{ end }}
+  {{- end }}

--- a/charts/theia.cloud/values.yaml
+++ b/charts/theia.cloud/values.yaml
@@ -18,6 +18,13 @@ app:
   # The logo of the application that should be displayed on the landing pages
   logo: logos/theiablueprint.svg
 
+  # Set a base64 encoded svg image that should be displayed on the landing pages.
+  # If this is given, the logo value above is ignored.
+  # On Linux, you can directly generate the base64 string when applying the chart like this:
+  # --set app.logoData=$(cat path/to/file.svg | base64 -w 0 -)
+  # Another way is to directly add the base64 string to the values file.
+  # logoData
+
 # Values related to certificates/Cert-manager
 issuer:
   # EMail address of the certificate issuer.


### PR DESCRIPTION
Adds a new value app.logoData to provide an external svg image in base64 format. If app.logoData is provided, this image is written to the landing page config map. Otherwise, the default image configured in app.logo is used as before.

Fix #33

Contributed on behalf of STMicroelectronics