### PR TITLE
Fix issues in helm charts during helm upgrade

### DIFF
--- a/charts/theia.cloud-base/templates/clusterissuer-production.yaml
+++ b/charts/theia.cloud-base/templates/clusterissuer-production.yaml
@@ -1,5 +1,3 @@
-{{- if not (lookup "cert-manager.io/v1" "ClusterIssuer" "" .Values.issuerprod.name) }}
-
 apiVersion: cert-manager.io/v1
 kind: ClusterIssuer
 metadata:
@@ -14,5 +12,4 @@ spec:
     - http01: 
         ingress:
             class: nginx
-
-{{- end }}
+            

--- a/charts/theia.cloud-base/templates/clusterissuer-selfsigned.yaml
+++ b/charts/theia.cloud-base/templates/clusterissuer-selfsigned.yaml
@@ -1,10 +1,7 @@
-{{- if not (lookup "cert-manager.io/v1" "ClusterIssuer" "" .Values.issuerstaging.name) }}
-
 apiVersion: cert-manager.io/v1
 kind: ClusterIssuer
 metadata:
   name: {{ .Values.issuerstaging.name }}
 spec:
   selfSigned: {}
-
-{{- end }}
+  

--- a/charts/theia.cloud-base/templates/operator-role.yaml
+++ b/charts/theia.cloud-base/templates/operator-role.yaml
@@ -1,5 +1,3 @@
-{{- if not (lookup "rbac.authorization.k8s.io/v1" "ClusterRole" "" .Values.operatorrole.name) }}
-
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
@@ -26,5 +24,4 @@ rules:
       - deployments
       - leases
     verbs: ["list", "create", "watch", "get", "patch", "delete", "update"]
-
-{{- end }}
+    

--- a/charts/theia.cloud-base/templates/service-role.yaml
+++ b/charts/theia.cloud-base/templates/service-role.yaml
@@ -1,5 +1,3 @@
-{{- if not (lookup "rbac.authorization.k8s.io/v1" "ClusterRole" "" .Values.servicerole.name) }}
-
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
@@ -21,5 +19,4 @@ rules:
     resources:
       - pods
     verbs: ["list", "get", "watch"]
-
-{{- end }}
+    

--- a/charts/theia.cloud/Chart.yaml
+++ b/charts/theia.cloud/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.8.1-v004
+version: 0.8.1-v005
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/theia.cloud/templates/instances-ingress-path-based.yaml
+++ b/charts/theia.cloud/templates/instances-ingress-path-based.yaml
@@ -20,7 +20,27 @@ spec:
   - hosts:
     - {{ tpl (.Values.hosts.paths.baseHost | toString) . }}
   {{- end }}
+  {{- if not (lookup "networking.k8s.io/v1" "Ingress" .Release.Namespace  (tpl (.Values.ingress.instanceName | toString) .) ) }}
   rules:
     - host: {{ tpl (.Values.hosts.paths.baseHost | toString) . }}
       http:
+  {{- else }}
+  rules:
+    {{ range $rule := (lookup "networking.k8s.io/v1" "Ingress" .Release.Namespace (tpl (.Values.ingress.instanceName | toString) .)).spec.rules }}
+    - host: {{ .host }}
+      {{ if .http }}
+      http:
+        paths:
+          {{ with index .http.paths 0 }}
+          - path: {{ .path }}
+            pathType: Prefix
+            backend:
+              service:
+                name: {{ .backend.service.name  }}
+                port:
+                  number: {{ .backend.service.port.number  }}
+          {{- end }}
+      {{ end }}
+    {{- end }}
+  {{- end }}
 {{- end }}

--- a/charts/theia.cloud/templates/instances-ingress.yaml
+++ b/charts/theia.cloud/templates/instances-ingress.yaml
@@ -26,7 +26,27 @@ spec:
     - {{ tpl (.Values.hosts.instance | toString) . }}
     secretName: ws-cert-secret
   {{- end }}
+  {{- if not (lookup "networking.k8s.io/v1" "Ingress" .Release.Namespace  (tpl (.Values.ingress.instanceName | toString) .) ) }}
   rules:
     - host: {{ tpl (.Values.hosts.instance | toString) . }}
       http:
+  {{- else }}
+  rules:
+    {{ range $rule := (lookup "networking.k8s.io/v1" "Ingress" .Release.Namespace (tpl (.Values.ingress.instanceName | toString) .)).spec.rules }}
+    - host: {{ .host }}
+      {{ if .http }}
+      http:
+        paths:
+          {{ with index .http.paths 0 }}
+          - path: {{ .path }}
+            pathType: Prefix
+            backend:
+              service:
+                name: {{ .backend.service.name  }}
+                port:
+                  number: {{ .backend.service.port.number  }}
+          {{- end }}
+      {{ end }}
+    {{- end }}
+  {{- end }}
 {{- end }}

--- a/charts/theia.cloud/templates/landing-page.yaml
+++ b/charts/theia.cloud/templates/landing-page.yaml
@@ -14,6 +14,8 @@ spec:
     metadata:
       labels:
         app: landing-page
+      annotations:
+        checksum/config: {{ include (print $.Template.BasePath "/landing-page-config-map.yaml") . | sha256sum }}
     spec:
       automountServiceAccountToken: false
       containers:

--- a/charts/theia.cloud/templates/service.yaml
+++ b/charts/theia.cloud/templates/service.yaml
@@ -14,6 +14,8 @@ spec:
     metadata:
       labels:
         app: service
+      annotations:
+        checksum/config: {{ include (print $.Template.BasePath "/service-configmap.yaml") . | sha256sum }}
     spec:
       # we need to be able to create and read sessions
       automountServiceAccountToken: true


### PR DESCRIPTION
* Copy existing rules when updating instance ingress eclipsesource/theia-cloud#206 
  * use lookup function to find existing rules
* Remove lookups from base eclipsesource/theia-cloud#204 
  * we allow to customize the name. user shall customize the name if they get any conflicts on install. using lookup like this leads to removal of the resources if they are existing
* Add configmap checksums to deployments eclipsesource/theia-cloud#202
  * will restart the deployments when there configmap changes

Ingress update should be tested with `2-01_try-now` (subdomain based) and `2-03_try-now_paths` (path based) test-configurations. 
* Install test configuration
* Change something in `instances-ingress-path-based.yaml` and `instances-ingress.yaml` e.g. increase the `nginx.ingress.kubernetes.io/proxy-buffer-size` slightly and update the helm chart version
* run `terraform apply` again with new chart. Verify that the changed value in the ingress has changed
* Start a session, repeat above steps, and verify the the session is still reachable with the same URL
* Start a further sessions, repeat above steps, and verify that both the sessions are still reachable with their URLs.
* Test again with other test-configuration

Base chart upgrade can be tested by just increasing the version. All Cluster Issuers and Cluster Roles should still exist and be updated. 

Configmap Upgrade can be tested with the reproducer mentioned on the ticket