### PR TITLE
Update versioning + introduce changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,10 @@
+# Changelog
+
+## [0.9.0] - TBD (estimated 2024-01-01)
+
+- [All charts] Align [versioning](https://github.com/eclipsesource/theia-cloud-helm#versioning) between all components and introduce changelog [#45](https://github.com/eclipsesource/theia-cloud-helm/pull/45) | [#258](https://github.com/eclipsesource/theia-cloud/pull/258) - contributed on behalf of STMicroelectronics
+- [All charts] Change CRD versions from `vXbeta` to `v1betaX` and only keep latest two versions [#46](https://github.com/eclipsesource/theia-cloud-helm/pull/46) | [#266](https://github.com/eclipsesource/theia-cloud/pull/266) - contributed on behalf of STMicroelectronics
+
+## [0.8.1] - 2023-10-01
+  
+- Last Milestone based version. No changelog available due to alpha-phase.

--- a/README.md
+++ b/README.md
@@ -10,27 +10,36 @@ There are three charts:
 
 ## Versioning
 
-`appVersion` will be updated to the used docker-image tag in all cases.
-
 The chart `version` should get updated on every change/commit/PR.\
 However only changed charts should get an increased version, e.g. when a commit changes the theia-cloud chart, only this chart version has to be increased.\
 See below for more information:
 
 ```yaml
 # Releases
-# follow semantic versioning (starting with release 1.0.0)
+# follow semantic versioning (starting with release 0.9.0)
 version: 1.0.0
 
 # Pre-Releases
-# append -v<number> to the next version. Number should be increased on every change/commit/PR
-version: 1.0.0-v001
-version: 1.0.0-v002
-# for special pre-releases, like milestone or release candidates will, please append further information at the end
-version: 1.0.0-v003-MS1
-version: 1.0.0-v004
-version: 1.0.0-v005-MS2
-version: 1.0.0-v006-RC1
+# append -next.X to the next version. X should be increased on every change/commit/PR
+version: 1.0.0-next.0
+version: 1.0.0-next.1
 ```
+
+The `appVersion` is pointing to the `<version>-next` tag this means that the images consumed are bound to change, when a new pre-release of that component is published.
+
+Therefore, you should only use full releases for deployments, as the next tag might change at any time.
+If you still want to use a next version you should pin the used images to a specific version (`<version>-next.<commitSHA>`).
+
+### Release a new version
+
+New release every three months.
+
+Provide a commit where the next parts are removed from the `version` and the `appVersion` fields of ALL charts.
+Also set the images used in charts to the version of the release.
+The release should be done after the main repository provided a release and the docker images were pushed.
+
+With next change after a release needs the version number should be bumped and `-next.0/-next` should be added to the version/appVersion fields.
+Furthermore, the new version, together with a release estimation date, should be added to the changelog.
 
 ## How to generate Chart READMEs
 

--- a/charts/theia-cloud-crds/Chart.yaml
+++ b/charts/theia-cloud-crds/Chart.yaml
@@ -15,10 +15,10 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.8.1-v004-MS3
+version: 0.9.0-next.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "0.8.1.MS3"
+appVersion: "0.9.0-next"

--- a/charts/theia.cloud-base/Chart.yaml
+++ b/charts/theia.cloud-base/Chart.yaml
@@ -15,10 +15,10 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.8.1-v004-MS3
+version: 0.9.0-next.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "0.8.1.MS3"
+appVersion: "0.9.0-next"

--- a/charts/theia.cloud-base/README.md
+++ b/charts/theia.cloud-base/README.md
@@ -1,6 +1,6 @@
 # theia-cloud-base
 
-![Version: 0.8.1-v004-MS3](https://img.shields.io/badge/Version-0.8.1--v004--MS3-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.8.1.MS3](https://img.shields.io/badge/AppVersion-0.8.1.MS3-informational?style=flat-square)
+![Version: 0.9.0-next.0](https://img.shields.io/badge/Version-0.9.0--next.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.9.0-next](https://img.shields.io/badge/AppVersion-0.9.0--next-informational?style=flat-square)
 
 Theia-cloud base chart
 

--- a/charts/theia.cloud/Chart.yaml
+++ b/charts/theia.cloud/Chart.yaml
@@ -15,10 +15,10 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.8.1-v009-MS3
+version: 0.9.0-next.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "0.8.1.MS3"
+appVersion: "0.9.0-next"

--- a/charts/theia.cloud/README.md
+++ b/charts/theia.cloud/README.md
@@ -1,6 +1,6 @@
 # theia-cloud
 
-![Version: 0.8.1-v009-MS3](https://img.shields.io/badge/Version-0.8.1--v009--MS3-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.8.1.MS3](https://img.shields.io/badge/AppVersion-0.8.1.MS3-informational?style=flat-square)
+![Version: 0.9.0-next.0](https://img.shields.io/badge/Version-0.9.0--next.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.9.0-next](https://img.shields.io/badge/AppVersion-0.9.0--next-informational?style=flat-square)
 
 A Helm chart for Theia.cloud
 
@@ -29,7 +29,7 @@ A Helm chart for Theia.cloud
 | hosts.useServicePortInHostname | bool | `false` | whether the service port needs to be part of the service URL (default: false) |
 | image | object | (see details below) | Docker image of the main application |
 | image.imagePullPolicy | string | `nil` | Optional: Override the imagePullPolicy for the main application's docker image. If this is omitted or empty, the root at .Values.imagePullPolicy is used. |
-| image.name | string | `"theiacloud/theia-cloud-demo:0.8.1.MS3"` | The name of docker image to be used |
+| image.name | string | `"theiacloud/theia-cloud-demo:0.9.0-next"` | The name of docker image to be used |
 | image.pullSecret | string | `""` | the image pull secret. Leave empty if registry is public |
 | image.timeoutLimit | string | `"30"` | Limit in minutes |
 | image.timeoutStrategy | string | `"FIXEDTIME"` | Configures how sessions will be stopped. This defines the strategy and the limit in minutes and will override any specification from an appDefinition. Possible values for strategy: - FIXEDTIME   Sessions will be stopped after a fixed limit |
@@ -54,7 +54,7 @@ A Helm chart for Theia.cloud
 | landingPage.additionalApps | string | `nil` | The page may show these additional apps in a drop down. This is a map. The key maps to the app definition name The value is the label that is supposed to be shown in the UI  Example: different-app-definition:   label: "Different App Definition" further-app-definition:   label: "Further App Definition" |
 | landingPage.appDefinition | string | `"theia-cloud-demo"` | the app id to launch |
 | landingPage.ephemeralStorage | bool | `true` | If set to true no persisted storage is used when creating sessions on the landing page. Set to false if you want to use persisted storage. |
-| landingPage.image | string | `"theiacloud/theia-cloud-landing-page:0.8.1.MS3"` | the landing page image to use |
+| landingPage.image | string | `"theiacloud/theia-cloud-landing-page:0.9.0-next"` | the landing page image to use |
 | landingPage.imagePullPolicy | string | `nil` | Optional: Override the imagePullPolicy for the landing page's docker image. If this is omitted or empty, the root at .Values.imagePullPolicy is used. |
 | landingPage.imagePullSecret | string | `nil` | Optional: the image pull secret |
 | monitor | object | (see details below) | Values to influence the monitor |
@@ -70,7 +70,7 @@ A Helm chart for Theia.cloud
 | operator.cloudProvider | string | `"K8S"` | Select your cloud provider. Possible values: - K8S      Plain Kubernetes - MINIKUBE Local deployment on Minikube |
 | operator.continueOnException | bool | `false` | Whether the operator should stop in cases where an exception is not handled |
 | operator.eagerStart | bool | `false` | Whether theia applications shall be started eager. This means that the application is already running without a user. When a user requests a new session, one of the already launched ones is assigned.  Currently only false is fully supported. |
-| operator.image | string | `"theiacloud/theia-cloud-operator:0.8.1.MS3v2"` | The operator image |
+| operator.image | string | `"theiacloud/theia-cloud-operator:0.9.0-next"` | The operator image |
 | operator.imagePullPolicy | string | `nil` | Optional: Override the imagePullPolicy for the operator's docker image. If this is omitted or empty, the root at .Values.imagePullPolicy is used. |
 | operator.imagePullSecret | string | `nil` | Optional: the image pull secret |
 | operator.leaderElection | object | (see details below) | Options to influence the operator's leader election |
@@ -81,10 +81,10 @@ A Helm chart for Theia.cloud
 | operator.requestedStorage | string | `"250Mi"` | The amount of requested storage for each persistent volume claim (PVC) for workspaces. This is directly passed to created PVCs and must be a valid Kubernetes quantity. See https://kubernetes.io/docs/reference/kubernetes-api/common-definitions/quantity/ |
 | operator.sessionsPerUser | string | `"1"` | Set the number of active sessions a single user can launch |
 | operator.storageClassName | string | `"default"` | The name of the storage class for persistent volume claims for workspaces. This storage class must be present on the cluster. Most cloud providers offer a default storage class without additional configuration. |
-| operator.wondershaperImage | string | `"theiacloud/theia-cloud-wondershaper:0.8.1.MS3"` | If bandwidthLimiter is set to WONDERSHAPER or K8SANNOTATIONANDWONDERSHAPER this image will be used for the wondershaper init container |
+| operator.wondershaperImage | string | `"theiacloud/theia-cloud-wondershaper:0.9.0-next"` | If bandwidthLimiter is set to WONDERSHAPER or K8SANNOTATIONANDWONDERSHAPER this image will be used for the wondershaper init container |
 | operatorrole.name | string | `"operator-api-access"` |  |
 | service | object | (see details below) | Values of the Theia.cloud REST service |
-| service.image | string | `"theiacloud/theia-cloud-service:0.8.1.MS3"` | The image to use |
+| service.image | string | `"theiacloud/theia-cloud-service:0.9.0-next"` | The image to use |
 | service.imagePullPolicy | string | `nil` | Optional: Override the imagePullPolicy for the service's docker image. If this is omitted or empty, the root at .Values.imagePullPolicy is used. |
 | service.imagePullSecret | string | `nil` | Optional: the image pull secret |
 | servicerole.name | string | `"service-api-access"` |  |

--- a/charts/theia.cloud/values.yaml
+++ b/charts/theia.cloud/values.yaml
@@ -36,7 +36,7 @@ issuer:
 # @default -- (see details below)
 image:
   # -- The name of docker image to be used
-  name: theiacloud/theia-cloud-demo:0.8.1.MS3
+  name: theiacloud/theia-cloud-demo:0.9.0-next
 
   # -- Optional: Override the imagePullPolicy for the main application's docker image.
   # If this is omitted or empty, the root at .Values.imagePullPolicy is used.
@@ -99,7 +99,7 @@ hosts:
 # @default -- (see details below)
 landingPage:
   # -- the landing page image to use
-  image: theiacloud/theia-cloud-landing-page:0.8.1.MS3
+  image: theiacloud/theia-cloud-landing-page:0.9.0-next
 
   # -- Optional: Override the imagePullPolicy for the landing page's docker image.
   # If this is omitted or empty, the root at .Values.imagePullPolicy is used.
@@ -161,7 +161,7 @@ keycloak:
 # @default -- (see details below)
 operator:
   # -- The operator image
-  image: theiacloud/theia-cloud-operator:0.8.1.MS3
+  image: theiacloud/theia-cloud-operator:0.9.0-next
 
   # -- Optional: Override the imagePullPolicy for the operator's docker image.
   # If this is omitted or empty, the root at .Values.imagePullPolicy is used.
@@ -190,7 +190,7 @@ operator:
   bandwidthLimiter: "K8SANNOTATION"
 
   # -- If bandwidthLimiter is set to WONDERSHAPER or K8SANNOTATIONANDWONDERSHAPER this image will be used for the wondershaper init container
-  wondershaperImage: theiacloud/theia-cloud-wondershaper:0.8.1.MS3
+  wondershaperImage: theiacloud/theia-cloud-wondershaper:0.9.0-next
 
   # -- Set the number of active sessions a single user can launch
   sessionsPerUser: "1"
@@ -253,7 +253,7 @@ operator:
 # @default -- (see details below)
 service:
   # -- The image to use
-  image: theiacloud/theia-cloud-service:0.8.1.MS3
+  image: theiacloud/theia-cloud-service:0.9.0-next
 
   # -- Optional: Override the imagePullPolicy for the service's docker image.
   # If this is omitted or empty, the root at .Values.imagePullPolicy is used.


### PR DESCRIPTION
The new versioning system is described in the README. 
Add changelog and provide generic entry for 0.8.1. 
Update all charts to version `0.9.0-next.0`.
Set the appVersion to `0.9.0-next`.

**Main repo PR:** https://github.com/eclipsesource/theia-cloud/pull/258

Contributed on behalf of STMicroelectronics