### PR TITLE
Fix CRD versioning

### DIFF
--- a/charts/theia-cloud-crds/templates/appdefinition-spec-resource.yaml
+++ b/charts/theia-cloud-crds/templates/appdefinition-spec-resource.yaml
@@ -11,7 +11,7 @@ spec:
     singular: appdefinition
   scope: Namespaced
   versions:
-    - name: v8beta
+    - name: v1beta8
       served: true
       storage: true
       # subresources describes the subresources for custom resources.
@@ -30,7 +30,7 @@ spec:
               properties:
                 name:
                   type: string
-                  pattern: '^[a-z0-9A-Z-_]+$'
+                  pattern: "^[a-z0-9A-Z-_]+$"
                 image:
                   type: string
                 imagePullPolicy:
@@ -97,15 +97,15 @@ spec:
                 - limitsMemory
                 - limitsCpu
             status:
-                type: object
-                properties:
-                  operatorStatus:
-                    type: string
-                  operatorMessage:
-                    type: string
+              type: object
+              properties:
+                operatorStatus:
+                  type: string
+                operatorMessage:
+                  type: string
           required:
             - spec
-    - name: v7beta
+    - name: v1beta7
       served: true
       storage: false
       # subresources describes the subresources for custom resources.
@@ -172,320 +172,9 @@ spec:
                         notifyAfter:
                           type: integer
             status:
-                type: object
-                properties:
-                  operatorStatus:
-                    type: string
-                  operatorMessage:
-                    type: string
-    - name: v6beta
-      served: true
-      storage: false
-      schema:
-        openAPIV3Schema:
-          type: object
-          properties:
-            spec:
               type: object
               properties:
-                name:
+                operatorStatus:
                   type: string
-                image:
+                operatorMessage:
                   type: string
-                imagePullPolicy:
-                  type: string
-                  enum: ["Always", "IfNotPresent", "Never"]
-                pullSecret:
-                  type: string
-                uid:
-                  type: integer
-                port:
-                  type: integer
-                ingressname:
-                  type: string
-                minInstances:
-                  type: integer
-                maxInstances:
-                  type: integer
-                timeout:
-                  type: object
-                  properties:
-                    strategy:
-                      type: string
-                    limit:
-                      type: integer
-                requestsMemory:
-                  type: string
-                requestsCpu:
-                  type: string
-                limitsMemory:
-                  type: string
-                limitsCpu:
-                  type: string
-                downlinkLimit:
-                  type: integer
-                uplinkLimit:
-                  type: integer
-                mountPath:
-                  type: string
-                monitor:
-                  type: object
-                  properties:
-                    port:
-                      type: integer
-                    activityTracker:
-                      type: object
-                      properties:
-                        timeoutAfter:
-                          type: integer
-                        notifyAfter:
-                          type: integer
-    - name: v5beta
-      served: true
-      storage: false
-      schema:
-        openAPIV3Schema:
-          type: object
-          properties:
-            spec:
-              type: object
-              properties:
-                name:
-                  type: string
-                image:
-                  type: string
-                imagePullPolicy:
-                  type: string
-                  enum: ["Always", "IfNotPresent", "Never"]
-                pullSecret:
-                  type: string
-                uid:
-                  type: integer
-                port:
-                  type: integer
-                host:
-                  type: string
-                ingressname:
-                  type: string
-                minInstances:
-                  type: integer
-                maxInstances:
-                  type: integer
-                timeout:
-                  type: object
-                  properties:
-                    strategy:
-                      type: string
-                    limit:
-                      type: integer
-                requestsMemory:
-                  type: string
-                requestsCpu:
-                  type: string
-                limitsMemory:
-                  type: string
-                limitsCpu:
-                  type: string
-                downlinkLimit:
-                  type: integer
-                uplinkLimit:
-                  type: integer
-                mountPath:
-                  type: string
-                monitor:
-                  type: object
-                  properties:
-                    port:
-                      type: integer
-                    activityTracker:
-                      type: object
-                      properties:
-                        timeoutAfter:
-                          type: integer
-                        notifyAfter:
-                          type: integer
-    - name: v4beta
-      served: true
-      storage: false
-      schema:
-        openAPIV3Schema:
-          type: object
-          properties:
-            spec:
-              type: object
-              properties:
-                name:
-                  type: string
-                image:
-                  type: string
-                imagePullPolicy:
-                  type: string
-                  enum: ["Always", "IfNotPresent", "Never"]
-                pullSecret:
-                  type: string
-                uid:
-                  type: integer
-                port:
-                  type: integer
-                host:
-                  type: string
-                ingressname:
-                  type: string
-                minInstances:
-                  type: integer
-                maxInstances:
-                  type: integer
-                timeout:
-                  type: object
-                  properties:
-                    strategy:
-                      type: string
-                    limit:
-                      type: integer
-                requestsMemory:
-                  type: string
-                requestsCpu:
-                  type: string
-                limitsMemory:
-                  type: string
-                limitsCpu:
-                  type: string
-                downlinkLimit:
-                  type: integer
-                uplinkLimit:
-                  type: integer
-                mountPath:
-                  type: string
-    - name: v3beta
-      served: true
-      storage: false
-      schema:
-        openAPIV3Schema:
-          type: object
-          properties:
-            spec:
-              type: object
-              properties:
-                name:
-                  type: string
-                image:
-                  type: string
-                pullSecret:
-                  type: string
-                uid:
-                  type: integer
-                port:
-                  type: integer
-                host:
-                  type: string
-                ingressname:
-                  type: string
-                minInstances:
-                  type: integer
-                maxInstances:
-                  type: integer
-                timeout:
-                  type: object
-                  properties:
-                    strategy:
-                      type: string
-                    limit:
-                      type: integer
-                requestsMemory:
-                  type: string
-                requestsCpu:
-                  type: string
-                limitsMemory:
-                  type: string
-                limitsCpu:
-                  type: string
-                downlinkLimit:
-                  type: integer
-                uplinkLimit:
-                  type: integer
-                mountPath:
-                  type: string
-    - name: v2beta
-      served: true
-      storage: false
-      schema:
-        openAPIV3Schema:
-          type: object
-          properties:
-            spec:
-              type: object
-              properties:
-                name:
-                  type: string
-                image:
-                  type: string
-                pullSecret:
-                  type: string
-                uid:
-                  type: integer
-                port:
-                  type: integer
-                host:
-                  type: string
-                ingressname:
-                  type: string
-                minInstances:
-                  type: integer
-                maxInstances:
-                  type: integer
-                killAfter:
-                  type: integer
-                requestsMemory:
-                  type: string
-                requestsCpu:
-                  type: string
-                limitsMemory:
-                  type: string
-                limitsCpu:
-                  type: string
-                downlinkLimit:
-                  type: integer
-                uplinkLimit:
-                  type: integer
-                mountPath:
-                  type: string
-    - name: v1beta
-      served: true
-      storage: false
-      schema:
-        openAPIV3Schema:
-          type: object
-          properties:
-            spec:
-              type: object
-              properties:
-                name:
-                  type: string
-                image:
-                  type: string
-                uid:
-                  type: integer
-                port:
-                  type: integer
-                host:
-                  type: string
-                ingressname:
-                  type: string
-                minInstances:
-                  type: integer
-                maxInstances:
-                  type: integer
-                killAfter:
-                  type: integer
-                requestsMemory:
-                  type: string
-                requestsCpu:
-                  type: string
-                limitsMemory:
-                  type: string
-                limitsCpu:
-                  type: string
-                downlinkLimit:
-                  type: integer
-                uplinkLimit:
-                  type: integer

--- a/charts/theia-cloud-crds/templates/session-spec-resource.yaml
+++ b/charts/theia-cloud-crds/templates/session-spec-resource.yaml
@@ -11,7 +11,7 @@ spec:
     singular: session
   scope: Namespaced
   versions:
-    - name : v6beta
+    - name : v1beta6
       served: true
       storage: true
       # subresources describes the subresources for custom resources.
@@ -68,7 +68,7 @@ spec:
                   type: string
           required:
             - spec
-    - name : v5beta
+    - name : v1beta5
       served: true
       storage: false
       # subresources describes the subresources for custom resources.
@@ -116,112 +116,4 @@ spec:
                 operatorStatus:
                   type: string
                 operatorMessage:
-                  type: string
-    - name : v4beta
-      served: true
-      storage: false
-      schema:
-        openAPIV3Schema:
-          type: object
-          properties:
-            spec:
-              type: object
-              properties:
-                name:
-                  type: string
-                workspace:
-                  type: string
-                appDefinition: # cached from workspace
-                  type: string
-                user: # cached from workspace
-                  type: string
-                url:
-                  type: string
-                error:
-                  type: string
-                sessionSecret:
-                  type: string
-                lastActivity:
-                  type: integer
-                envVars:
-                  type: object
-                  additionalProperties:
-                    x-kubernetes-int-or-string: true
-                envVarsFromConfigMaps:
-                  type: array
-                  items:
-                    type: string
-                envVarsFromSecrets:
-                  type: array
-                  items:
-                    type: string
-    - name : v3beta
-      served: true
-      storage: false
-      schema:
-        openAPIV3Schema:
-          type: object
-          properties:
-            spec:
-              type: object
-              properties:
-                name:
-                  type: string
-                workspace:
-                  type: string
-                appDefinition: # cached from workspace
-                  type: string
-                user: # cached from workspace
-                  type: string
-                url:
-                  type: string
-                error:
-                  type: string
-                sessionSecret:
-                  type: string
-                lastActivity:
-                  type: integer
-    - name : v2beta
-      served: true
-      storage: false
-      schema:
-        openAPIV3Schema:
-          type: object
-          properties:
-            spec:
-              type: object
-              properties:
-                name:
-                  type: string
-                workspace:
-                  type: string
-                appDefinition: # cached from workspace
-                  type: string
-                user:          # cached from workspace
-                  type: string
-                url:
-                  type: string
-                error:
-                  type: string
-                lastActivity:
-                  type: integer
-    - name : v1beta
-      served: true
-      storage: false
-      schema:
-        openAPIV3Schema:
-          type: object
-          properties:
-            spec:
-              type: object
-              properties:
-                name:
-                  type: string
-                appDefinition:
-                  type: string
-                user:
-                  type: string
-                url:
-                  type: string
-                error:
                   type: string

--- a/charts/theia-cloud-crds/templates/workspace-spec-resource.yaml
+++ b/charts/theia-cloud-crds/templates/workspace-spec-resource.yaml
@@ -11,7 +11,7 @@ spec:
     singular: workspace
   scope: Namespaced
   versions:
-    - name : v3beta
+    - name : v1beta3
       served: true
       storage: true
       # subresources describes the subresources for custom resources.
@@ -63,7 +63,7 @@ spec:
                       type: string
           required:
             - spec
-    - name : v2beta
+    - name : v1beta2
       served: true
       storage: false
       # subresources describes the subresources for custom resources.
@@ -108,25 +108,3 @@ spec:
                       type: string
                     message:
                       type: string
-
-    - name : v1beta
-      served: true
-      storage: false
-      schema:
-        openAPIV3Schema:
-          type: object
-          properties:
-            spec:
-              type: object
-              properties:
-                name:
-                  type: string
-                label:
-                  type: string
-                appDefinition: # last app definition that ran on this workspace
-                  type: string
-                user:          # user who created the workspace
-                  type: string
-                storage:
-                  type: string
-                  

--- a/charts/theia.cloud/templates/theia-appdefinition-spec.yaml
+++ b/charts/theia.cloud/templates/theia-appdefinition-spec.yaml
@@ -1,4 +1,4 @@
-apiVersion: theia.cloud/v8beta
+apiVersion: theia.cloud/v1beta8
 kind: AppDefinition
 metadata:
   name: theia-cloud-demo


### PR DESCRIPTION
* Rename CRDs versions from vXbeta to v1betaX.
* Only keep last two versions of each CRD and fix version names
* This PR should bring all required prerequisites to implement a conversion hook for new CRD versions

Contributed on behalf of STMicroelectronics