### PR TITLE
Make demo application optional

### DIFF
--- a/.theia/settings.json
+++ b/.theia/settings.json
@@ -1,0 +1,5 @@
+{
+    "[markdown]": {
+        "editor.defaultFormatter": "esbenp.prettier-vscode"
+    }
+}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,12 @@
   - `Workspace.v1beta4`: Move the `error` field from the spec to the status. Also add the `error` field to `Workspace.v1beta3` as it was missing
 - [theia-cloud-crds] Remove `timeout.strategy` from AppDefinition [#](https://github.com/eclipsesource/theia-cloud-helm/pull/49) | [#283](https://github.com/eclipsesource/theia-cloud/pull/283) - contributed on behalf of STMicroelectronics
   - `AppDefinition.v1beta9`: Removed `timeout.strategy` and `timeout.limit` is now just `timeout`. This was done, as there is only one Strategy left.
+- [theia-cloud-crds] Provide shortnames for AppDefinition (appdef, ad) and Workspaces (ws) [#52](https://github.com/eclipsesource/theia-cloud-helm/pull/52) | [#289](https://github.com/eclipsesource/theia-cloud/pull/289) - contributed on behalf of STMicroelectronics
+- [theia-cloud] Make demo application optional (`demoApplication.install`) and group relevant fields together [#52](https://github.com/eclipsesource/theia-cloud-helm/pull/52) | [#289](https://github.com/eclipsesource/theia-cloud/pull/289) - contributed on behalf of STMicroelectronics
+  - `image` -> `demoApplication`
+  - `monitor.port` -> `demoApplication.monitor.port`
+  - `monitor.activityTracker.timeoutAfter` -> `demoApplication.monitor.activityTracker.timeoutAfter`
+  - `monitor.activityTracker.notifyAfter` -> `demoApplication.monitor.activityTracker.notifyAfter`
 
 ## [0.9.0] - 2024-01-23
 
@@ -18,5 +24,5 @@
 - [All charts] Change CRD versions from `vXbeta` to `v1betaX` and only keep latest two versions [#46](https://github.com/eclipsesource/theia-cloud-helm/pull/46) | [#266](https://github.com/eclipsesource/theia-cloud/pull/266) - contributed on behalf of STMicroelectronics
 
 ## [0.8.1] - 2023-10-01
-  
+
 - Last Milestone based version. No changelog available due to alpha-phase.

--- a/charts/theia-cloud-crds/Chart.yaml
+++ b/charts/theia-cloud-crds/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.10.0-next.1
+version: 0.10.0-next.2
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/theia-cloud-crds/README.md
+++ b/charts/theia-cloud-crds/README.md
@@ -1,6 +1,6 @@
 # theia-cloud-crds
 
-![Version: 0.10.0-next.1](https://img.shields.io/badge/Version-0.10.0--next.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.10.0-next](https://img.shields.io/badge/AppVersion-0.10.0--next-informational?style=flat-square)
+![Version: 0.10.0-next.2](https://img.shields.io/badge/Version-0.10.0--next.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.10.0-next](https://img.shields.io/badge/AppVersion-0.10.0--next-informational?style=flat-square)
 
 A Helm chart for the custom resource definitions (CRDs) of Theia Cloud
 

--- a/charts/theia-cloud-crds/templates/appdefinition-spec-resource.yaml
+++ b/charts/theia-cloud-crds/templates/appdefinition-spec-resource.yaml
@@ -11,6 +11,9 @@ spec:
     listKind: AppDefinitionList
     plural: appdefinitions
     singular: appdefinition
+    shortNames:
+    - appdef
+    - ad
   scope: Namespaced
   versions:
     - name: v1beta9

--- a/charts/theia-cloud-crds/templates/workspace-spec-resource.yaml
+++ b/charts/theia-cloud-crds/templates/workspace-spec-resource.yaml
@@ -11,6 +11,8 @@ spec:
     listKind: WorkspaceList
     plural: workspaces
     singular: workspace
+    shortNames:
+    - ws
   scope: Namespaced
   versions:
     - name : v1beta4

--- a/charts/theia.cloud/Chart.yaml
+++ b/charts/theia.cloud/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.10.0-next.1
+version: 0.10.0-next.2
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/theia.cloud/README.md
+++ b/charts/theia.cloud/README.md
@@ -20,7 +20,7 @@ A Helm chart for Theia.cloud
 | demoApplication.monitor.activityTracker | object | (see details below) | Values that are used by the activityTracker module |
 | demoApplication.monitor.activityTracker.notifyAfter | int | `25` | Minutes of inactivity that lead to a warning displayed to the user Make greater than timeoutAfter to disable |
 | demoApplication.monitor.activityTracker.timeoutAfter | int | `30` | Minutes of inactivity that lead to pod shutdown |
-| demoApplication.monitor.port | int | `3000` | At which port the monitor extension is available Choose the same as the application port for the theia extension |
+| demoApplication.monitor.port | int | `3000` | At which port the monitor extension is available For the Theia extension take the same as the application port For the VSCode extension take 8081 (default) or the port specified via the THEIACLOUD_MONITOR_PORT env variable |
 | demoApplication.name | string | `"theiacloud/theia-cloud-demo:0.10.0-next"` | The name of docker image to be used |
 | demoApplication.pullSecret | string | `""` | the image pull secret. Leave empty if registry is public |
 | demoApplication.timeout | string | `"30"` | Limit in minutes |

--- a/charts/theia.cloud/README.md
+++ b/charts/theia.cloud/README.md
@@ -1,6 +1,6 @@
 # theia-cloud
 
-![Version: 0.10.0-next.1](https://img.shields.io/badge/Version-0.10.0--next.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.10.0-next](https://img.shields.io/badge/AppVersion-0.10.0--next-informational?style=flat-square)
+![Version: 0.10.0-next.2](https://img.shields.io/badge/Version-0.10.0--next.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.10.0-next](https://img.shields.io/badge/AppVersion-0.10.0--next-informational?style=flat-square)
 
 A Helm chart for Theia.cloud
 
@@ -13,6 +13,17 @@ A Helm chart for Theia.cloud
 | app.logo | string | `"logos/theiablueprint.svg"` | The logo of the application that should be displayed on the landing pages |
 | app.logoData | string | `nil` | set app.logoData=$(cat path/to/file.svg | base64 -w 0 -) Another way is to directly add the base64 string to the values file. |
 | app.name | string | `"Theia Blueprint"` | The name of the application that should be displayed on the landing pages |
+| demoApplication | object | (see details below) | Information about the demo application to be installed |
+| demoApplication.imagePullPolicy | string | `nil` | Optional: Override the imagePullPolicy for the main application's docker image. If this is omitted or empty, the root at .Values.imagePullPolicy is used. |
+| demoApplication.install | bool | `true` | Should the demo application be installed |
+| demoApplication.monitor | object | (see details below) | Values that are used by the monitor |
+| demoApplication.monitor.activityTracker | object | (see details below) | Values that are used by the activityTracker module |
+| demoApplication.monitor.activityTracker.notifyAfter | int | `25` | Minutes of inactivity that lead to a warning displayed to the user Make greater than timeoutAfter to disable |
+| demoApplication.monitor.activityTracker.timeoutAfter | int | `30` | Minutes of inactivity that lead to pod shutdown |
+| demoApplication.monitor.port | int | `3000` | At which port the monitor extension is available Choose the same as the application port for the theia extension |
+| demoApplication.name | string | `"theiacloud/theia-cloud-demo:0.10.0-next"` | The name of docker image to be used |
+| demoApplication.pullSecret | string | `""` | the image pull secret. Leave empty if registry is public |
+| demoApplication.timeout | string | `"30"` | Limit in minutes |
 | hosts | object | (see details below) | You may adjust the hostname below. |
 | hosts.instance | string | `"ws.192.168.39.173.nip.io"` | hostname for the launched Theia-applications |
 | hosts.landing | string | `"theia.cloud.192.168.39.173.nip.io"` | hostname of the landing page |
@@ -27,11 +38,6 @@ A Helm chart for Theia.cloud
 | hosts.tls | bool | `true` | Does Theia Cloud expect TLS connections (true) or is TLS terminated outside of Theia Cloud (e.g. via a Load Balancer) (false) |
 | hosts.usePaths | bool | `false` | Use paths configures that all services should run on the same host but on different paths. true uses paths false uses an explicit host for each service |
 | hosts.useServicePortInHostname | bool | `false` | whether the service port needs to be part of the service URL (default: false) |
-| image | object | (see details below) | Docker image of the main application |
-| image.imagePullPolicy | string | `nil` | Optional: Override the imagePullPolicy for the main application's docker image. If this is omitted or empty, the root at .Values.imagePullPolicy is used. |
-| image.name | string | `"theiacloud/theia-cloud-demo:0.10.0-next"` | The name of docker image to be used |
-| image.pullSecret | string | `""` | the image pull secret. Leave empty if registry is public |
-| image.timeout | string | `"30"` | Limit in minutes |
 | imagePullPolicy | string | `"Always"` | The default imagePullPolicy for containers of theia cloud. Can be overridden for individual components by specifying the imagePullPolicy variable there. Possible values: - Always - IfNotPresent - Never |
 | ingress | object | (see details below) | Values to influence the ingresses |
 | ingress.clusterIssuer | string | `"letsencrypt-prod"` | The cluster issuer to use |
@@ -54,14 +60,11 @@ A Helm chart for Theia.cloud
 | landingPage.image | string | `"theiacloud/theia-cloud-landing-page:0.10.0-next"` | the landing page image to use |
 | landingPage.imagePullPolicy | string | `nil` | Optional: Override the imagePullPolicy for the landing page's docker image. If this is omitted or empty, the root at .Values.imagePullPolicy is used. |
 | landingPage.imagePullSecret | string | `nil` | Optional: the image pull secret |
-| monitor | object | (see details below) | Values to influence the monitor |
+| monitor | object | (see details below) | Values to influence the monitor initialization on the operator |
 | monitor.activityTracker | object | (see details below) | Values to influence the activityTracker module |
 | monitor.activityTracker.enable | bool | `true` | Should the activityTracker module be enabled |
-| monitor.activityTracker.interval | int | `1` | Minutes between re-ping by the operator |
-| monitor.activityTracker.notifyAfter | int | `25` | Minutes of inactivity that lead to a warning displayed to the user Make greater than timeoutAfter to disable |
-| monitor.activityTracker.timeoutAfter | int | `30` | Minutes of inactivity that lead to pod shutdown |
+| monitor.activityTracker.interval | int | `1` | Minutes between re-pinging the pods |
 | monitor.enable | bool | `true` | Should the monitor be enabled |
-| monitor.port | int | `3000` | At which port the monitor extension is available Choose the same as the application port for the theia extension |
 | operator | object | (see details below) | Values related to the operator |
 | operator.bandwidthLimiter | string | `"K8SANNOTATION"` | Whether Theia Cloud shall limit network speed. This might not be fully supported on all cloud provider/in all clusters. Possible values: - K8SANNOTATION                   Set via kubernetes annotations (kubernetes.io/egress-bandwidth and kubernetes.io/ingress-bandwidth) - WONDERSHAPER                    Set via wondershaper init container - K8SANNOTATIONANDWONDERSHAPER    Set Kubernetes annotations and use wondershaper init container |
 | operator.cloudProvider | string | `"K8S"` | Select your cloud provider. Possible values: - K8S      Plain Kubernetes - MINIKUBE Local deployment on Minikube |

--- a/charts/theia.cloud/templates/theia-appdefinition-spec.yaml
+++ b/charts/theia.cloud/templates/theia-appdefinition-spec.yaml
@@ -1,18 +1,19 @@
+{{- if .Values.demoApplication.install }}
 apiVersion: theia.cloud/v1beta9
 kind: AppDefinition
 metadata:
   name: theia-cloud-demo
 spec:
   name: theia-cloud-demo
-  image: {{ tpl (.Values.image.name | toString) . }}
-  imagePullPolicy: {{ if .Values.image.imagePullPolicy }}{{ tpl (.Values.image.imagePullPolicy | toString) . }}{{ else }}{{ tpl (.Values.imagePullPolicy | toString) . }}{{ end }}
-  pullSecret: {{ tpl (.Values.image.pullSecret | toString) . }}
+  image: {{ tpl (.Values.demoApplication.name | toString) . }}
+  imagePullPolicy: {{ if .Values.demoApplication.imagePullPolicy }}{{ tpl (.Values.demoApplication.imagePullPolicy | toString) . }}{{ else }}{{ tpl (.Values.imagePullPolicy | toString) . }}{{ end }}
+  pullSecret: {{ tpl (.Values.demoApplication.pullSecret | toString) . }}
   uid: 101
   port: 3000
   ingressname: {{ tpl (.Values.ingress.instanceName | toString) . }}
   minInstances: 0
   maxInstances: 10
-  timeout: {{ tpl (.Values.image.timeout | toString) . }}
+  timeout: {{ tpl (.Values.demoApplication.timeout | toString) . }}
   requestsMemory: 1000M
   limitsMemory: 1200M
   requestsCpu: "100m"
@@ -20,12 +21,13 @@ spec:
   downlinkLimit: 30000
   uplinkLimit: 30000
   mountPath: "/home/project/persisted"
-  {{- if .Values.monitor.enable }}
+  {{- if .Values.demoApplication.monitor }}
   monitor:
-    port: {{ tpl (.Values.monitor.port | toString) . }}
-    {{- if .Values.monitor.activityTracker.enable }}
+    port: {{ tpl (.Values.demoApplication.monitor.port | toString) . }}
+    {{- if .Values.demoApplication.monitor.activityTracker }}
     activityTracker:
-      timeoutAfter: {{ tpl (.Values.monitor.activityTracker.timeoutAfter | toString) .  }}
-      notifyAfter: {{ tpl (.Values.monitor.activityTracker.notifyAfter | toString) .  }}
+      timeoutAfter: {{ tpl (.Values.demoApplication.monitor.activityTracker.timeoutAfter | toString) .  }}
+      notifyAfter: {{ tpl (.Values.demoApplication.monitor.activityTracker.notifyAfter | toString) .  }}
     {{- end }}
   {{- end }}
+{{- end }}

--- a/charts/theia.cloud/values.yaml
+++ b/charts/theia.cloud/values.yaml
@@ -32,9 +32,11 @@ issuer:
   # -- EMail address of the certificate issuer.
   email: mmorlock@example.com
 
-# -- Docker image of the main application
+# -- Information about the demo application to be installed
 # @default -- (see details below)
-image:
+demoApplication:
+  # -- Should the demo application be installed
+  install: true
   # -- The name of docker image to be used
   name: theiacloud/theia-cloud-demo:0.10.0-next
 
@@ -47,6 +49,21 @@ image:
 
   # -- Limit in minutes
   timeout: "30"
+
+  # -- Values that are used by the monitor
+  # @default -- (see details below)
+  monitor:
+    # -- At which port the monitor extension is available
+    # Choose the same as the application port for the theia extension
+    port: 3000  
+    # -- Values that are used by the activityTracker module
+    # @default -- (see details below)
+    activityTracker:
+      # -- Minutes of inactivity that lead to pod shutdown
+      timeoutAfter: 30
+      # -- Minutes of inactivity that lead to a warning displayed to the user
+      # Make greater than timeoutAfter to disable
+      notifyAfter: 25
 
 # -- You may adjust the hostname below.
 # @default -- (see details below)
@@ -284,23 +301,15 @@ operatorrole:
 servicerole:
   name: service-api-access
 
-# -- Values to influence the monitor
+# -- Values to influence the monitor initialization on the operator
 # @default -- (see details below)
 monitor:
   # -- Should the monitor be enabled
   enable: true
-  # -- At which port the monitor extension is available
-  # Choose the same as the application port for the theia extension
-  port: 3000
   # -- Values to influence the activityTracker module
   # @default -- (see details below)
   activityTracker:
     # -- Should the activityTracker module be enabled
     enable: true
-    # -- Minutes between re-ping by the operator
+    # -- Minutes between re-pinging the pods
     interval: 1
-    # -- Minutes of inactivity that lead to pod shutdown
-    timeoutAfter: 30
-    # -- Minutes of inactivity that lead to a warning displayed to the user
-    # Make greater than timeoutAfter to disable
-    notifyAfter: 25

--- a/charts/theia.cloud/values.yaml
+++ b/charts/theia.cloud/values.yaml
@@ -54,7 +54,8 @@ demoApplication:
   # @default -- (see details below)
   monitor:
     # -- At which port the monitor extension is available
-    # Choose the same as the application port for the theia extension
+    # For the Theia extension take the same as the application port
+    # For the VSCode extension take 8081 (default) or the port specified via the THEIACLOUD_MONITOR_PORT env variable
     port: 3000  
     # -- Values that are used by the activityTracker module
     # @default -- (see details below)


### PR DESCRIPTION
Also group together demo application relevant values in demoApplication:
  - `image` -> `demoApplication`
  - `monitor.port` -> `demoApplication.monitor.port`
  - `monitor.activityTracker.timeoutAfter` -> `demoApplication.monitor.activityTracker.timeoutAfter`
  - `monitor.activityTracker.notifyAfter` -> `demoApplication.monitor.activityTracker.notifyAfter`

Provide shortnames for AppDefinition (appdef, ad) and Workspaces (ws)

Main-Repo PR: https://github.com/eclipsesource/theia-cloud/pull/289

Contributed on behalf of STMicroelectronics