### PR TITLE
Add configurable image preloading

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [0.11.0] - estimated 2024-07
 
 - [theia-cloud-crds] Add option field to CRDs and increase version to `Session.v1beta8`, `Workspace.v1beta5` and `AppDefinition.v1beta10` [#55](https://github.com/eclipsesource/theia-cloud-helm/pull/55) | [#293](https://github.com/eclipsesource/theia-cloud/pull/293)
+- [theia-cloud] Add configurable image preloading [#56](https://github.com/eclipsesource/theia-cloud-helm/pull/56)
 
 ## [0.10.0] - 2024-04-02
 

--- a/charts/theia.cloud/Chart.yaml
+++ b/charts/theia.cloud/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.11.0-next.0
+version: 0.11.0-next.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/theia.cloud/README.md
+++ b/charts/theia.cloud/README.md
@@ -83,6 +83,10 @@ A Helm chart for Theia.cloud
 | operator.storageClassName | string | `"default"` | The name of the storage class for persistent volume claims for workspaces. This storage class must be present on the cluster. Most cloud providers offer a default storage class without additional configuration. |
 | operator.wondershaperImage | string | `"theiacloud/theia-cloud-wondershaper:0.11.0-next"` | If bandwidthLimiter is set to WONDERSHAPER or K8SANNOTATIONANDWONDERSHAPER this image will be used for the wondershaper init container |
 | operatorrole.name | string | `"operator-api-access"` |  |
+| preloading | object | (see details below) | Values to configure preloading of images on Kubernetes nodes. |
+| preloading.enable | bool | `true` | Is image preloading enabled. |
+| preloading.imagePullPolicy | string | `nil` | Optional: Override the imagePullPolicy for the image preloading containers. If this is omitted or empty, the root at .Values.imagePullPolicy is used. |
+| preloading.images | list | `[]` | Images to preload. Images must support running /bin/sh. If the list is empty and demoApplication.install == true, demoApplication.name is automatically added. |
 | service | object | (see details below) | Values of the Theia.cloud REST service |
 | service.image | string | `"theiacloud/theia-cloud-service:0.11.0-next"` | The image to use |
 | service.imagePullPolicy | string | `nil` | Optional: Override the imagePullPolicy for the service's docker image. If this is omitted or empty, the root at .Values.imagePullPolicy is used. |

--- a/charts/theia.cloud/templates/image-preloading.yaml
+++ b/charts/theia.cloud/templates/image-preloading.yaml
@@ -1,0 +1,66 @@
+{{ if .Values.preloading.enable -}}
+
+{{- /*
+If the image preloading list is empty and the demo application is installed,
+add the demo application image to the list.
+If the list is not empty, it was explicitly overridden by the user and used as is.
+Initialize the $images variable because otherwise it is scoped to the if/else
+*/ -}}
+{{- $images := list -}}
+{{- if and (not .Values.preloading.images) .Values.demoApplication.install -}}
+  {{- $images = list .Values.demoApplication.name -}}
+{{- else -}}
+  {{- $images = .Values.preloading.images -}}
+{{- end -}}
+
+{{- /* Set image pull policy to local variable for increase readability. */ -}}
+{{- $imagePullPolicy := tpl (.Values.imagePullPolicy | toString) . -}}
+{{- if .Values.preloading.imagePullPolicy -}}
+  {{- $imagePullPolicy = tpl ($.Values.preloading.imagePullPolicy | toString) . -}}
+{{- end -}}
+
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: image-preloading
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: image-preloading
+    app.kubernetes.io/name: image-preloading
+    app.kubernetes.io/part-of: theia-cloud
+spec:
+  selector:
+    matchLabels:
+      app: image-preloading
+      app.kubernetes.io/name: image-preloading
+      app.kubernetes.io/part-of: theia-cloud
+  template:
+    metadata:
+      labels:
+        app: image-preloading
+        app.kubernetes.io/name: image-preloading
+        app.kubernetes.io/part-of: theia-cloud
+    spec:
+      # The pod can be killed instantly because it doesn't do any work requiring graceful shutdown
+      terminationGracePeriodSeconds: 0
+      initContainers:
+      {{- range $index, $image := $images }}
+      - name: image-preload-{{ $index }}
+        image: {{ $image }}
+        imagePullPolicy: {{ $imagePullPolicy }}
+        command: ["/bin/sh", "-c"]
+        args:
+        - "echo 'Loaded image {{ $image }}'; exit 0"
+      {{- end }}
+      # Run the pause container to make the Pod go into the Running state without consuming resources
+      containers:
+      - name: run
+        image: registry.k8s.io/pause:3.9
+        resources:
+          limits:
+            cpu: 1m
+            memory: 8M
+          requests:
+            cpu: 1m
+            memory: 8M
+{{- end }}

--- a/charts/theia.cloud/values.yaml
+++ b/charts/theia.cloud/values.yaml
@@ -314,3 +314,16 @@ monitor:
     enable: true
     # -- Minutes between re-pinging the pods
     interval: 1
+
+# -- Values to configure preloading of images on Kubernetes nodes.
+# @default -- (see details below)
+preloading:
+  # -- Is image preloading enabled.
+  enable: true
+  # -- Images to preload. Images must support running /bin/sh.
+  # If the list is empty and demoApplication.install == true,
+  # demoApplication.name is automatically added.
+  images: []
+  # -- Optional: Override the imagePullPolicy for the image preloading containers.
+  # If this is omitted or empty, the root at .Values.imagePullPolicy is used.
+  imagePullPolicy:


### PR DESCRIPTION
Extends the main chart to facilitate preloading images on all nodes via a daemon set. This increases startup performance on nodes which did not contain a session because the application image will already be present.

All images configured in the values are preloaded. One special case is handled: If no images are configured (the default) but image preloading and the demo application are both enabled, the demo image is still automatically preloaded.

### Testing

You can test this with the terraform test configurations. Beware that the 0.11.0-next application image is not published yet. Thus, you need to set it back to 0.10.0-next for the image pre-pull to work.

I tested the automatic pulling of the demo image on minikube. Inserting of manually configured images was "only" tested using `helm template`.