### PR TITLE
Extend landing page configuration options for logo and texts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - [theia-cloud-crds] Add option field to CRDs and increase version to `Session.v1beta8`, `Workspace.v1beta5` and `AppDefinition.v1beta10` [#55](https://github.com/eclipsesource/theia-cloud-helm/pull/55) | [#293](https://github.com/eclipsesource/theia-cloud/pull/293)
 - [theia-cloud] Add configurable image preloading [#56](https://github.com/eclipsesource/theia-cloud-helm/pull/56)
+- [theia-cloud] Add landing page configuration options for logo file extension, loading text, user info title & text [#58](https://github.com/eclipsesource/theia-cloud-helm/pull/58) - contributed on behalf of STMicroelectronics
 
 ## [0.10.0] - 2024-04-02
 

--- a/charts/theia.cloud/Chart.yaml
+++ b/charts/theia.cloud/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.11.0-next.1
+version: 0.11.0-next.2
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/theia.cloud/templates/landing-page-config-map.yaml
+++ b/charts/theia.cloud/templates/landing-page-config-map.yaml
@@ -1,3 +1,4 @@
+{{- $logoFileExtension :=  tpl (.Values.app.logoFileExtension | toString) . -}}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -27,12 +28,23 @@ data:
         },
         {{- end }}
       ],
+      logoFileExtension: "{{ $logoFileExtension }}",
+      disableInfo: {{ tpl (.Values.landingPage.disableInfo | toString) . }},
+      {{- if .Values.landingPage.infoText }}
+      infoText: "{{ tpl (.Values.landingPage.infoText | toString) . }}",
+      {{- end }}
+      {{- if .Values.landingPage.infoTitle }}
+      infoTitle: "{{ tpl (.Values.landingPage.infoTitle | toString) . }}",
+      {{- end }}
+      {{- if .Values.landingPage.loadingText }}
+      loadingText: "{{ tpl (.Values.landingPage.loadingText | toString) . }}",
+      {{- end }}
     };
 binaryData:
   {{- if .Values.app.logoData }}
-  {{ print "logo.svg: "}}{{ .Values.app.logoData }}
+  {{ printf "logo.%s: " $logoFileExtension }}{{ .Values.app.logoData }}
   {{- else }}
   {{- range $path, $bytes := .Files.Glob (printf "%s" .Values.app.logo)}}
-  {{ print "logo.svg: "}}{{ $.Files.Get $path | b64enc }}
+  {{ printf "logo.%s: " $logoFileExtension }}{{ $.Files.Get $path | b64enc }}
   {{ end }}
   {{- end }}

--- a/charts/theia.cloud/templates/landing-page.yaml
+++ b/charts/theia.cloud/templates/landing-page.yaml
@@ -1,3 +1,4 @@
+{{- $logoFileName :=  printf "logo.%s" (tpl (.Values.app.logoFileExtension | toString) .) -}}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -37,8 +38,8 @@ spec:
               mountPath: /usr/share/nginx/html/config.js
               subPath: config.js
             - name: landing-page-config
-              mountPath: /usr/share/nginx/html/logo.svg
-              subPath: logo.svg
+              mountPath: {{ printf "/usr/share/nginx/html/%s" $logoFileName }}
+              subPath: {{ $logoFileName }}
       {{- if .Values.landingPage.imagePullSecret }}
       imagePullSecrets:
         - name: {{ tpl (.Values.landingPage.imagePullSecret | toString) . }}

--- a/charts/theia.cloud/values.yaml
+++ b/charts/theia.cloud/values.yaml
@@ -26,6 +26,11 @@ app:
   # Another way is to directly add the base64 string to the values file.
   logoData:
 
+  # -- The file extension of the logo. Must be set to match the logo respectively the logoData.
+  # This is required because browsers cannot show a binary image (e.g. png) with a svg ending
+  # and vice-versa.
+  logoFileExtension: 'svg'
+
 # -- Values related to certificates/Cert-manager
 # @default -- (see details below)
 issuer:
@@ -142,6 +147,21 @@ landingPage:
     #   label: "Different App Definition"
     # further-app-definition:
     #   label: "Further App Definition"
+
+  # -- Should showing info title and text below the launch button be disabled
+  # true hides the info title and text
+  # false shows the info title and text
+  disableInfo: false
+  # -- Optional: If specified with a value, this overrides the info text shown on the landing page.
+  # Empty values are ignored. Use `disableInfo` to deactivate showing the info completely.
+  infoText:
+  # -- Optional: If specified with a value, this overrides the title of the info text shown on the landing page.
+  # Empty values are ignored. Use `disableInfo` to deactivate showing the info completely.
+  infoTitle:
+
+  # -- Optional: If specified with a value, this overrides the message shown to the user while the session is started.
+  # Empty values are ignored and the default text is used.
+  loadingText:
 
 # -- Values related to Keycloak
 # @default -- (see details below)


### PR DESCRIPTION
Add configuration options for the following:
- logo file extension: Allows using image formats other than svg
- info text and title: Configure the info texts shown on the landing page
- loading text: Configure the text shown while loading the session

Contributed on behalf of STMicroelectronics