### PR TITLE
Add conditional install for CA and Prod ClusterIssuer

### DIFF
--- a/charts/theia-cloud-base/Chart.yaml
+++ b/charts/theia-cloud-base/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.11.0-next.1
+version: 0.11.0-next.2
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/theia-cloud-base/templates/clusterissuer-for-ca.yaml
+++ b/charts/theia-cloud-base/templates/clusterissuer-for-ca.yaml
@@ -1,4 +1,4 @@
-{{- if eq .Values.issuerca.enable false }}
+{{- if .Values.issuerca.enable }}
 apiVersion: cert-manager.io/v1
 kind: ClusterIssuer
 metadata:

--- a/charts/theia-cloud-base/templates/clusterissuer-for-ca.yaml
+++ b/charts/theia-cloud-base/templates/clusterissuer-for-ca.yaml
@@ -1,4 +1,4 @@
-{{- if eq .Values.issuerca.useExisting false }}
+{{- if eq .Values.issuerca.enable false }}
 apiVersion: cert-manager.io/v1
 kind: ClusterIssuer
 metadata:

--- a/charts/theia-cloud-base/templates/clusterissuer-for-ca.yaml
+++ b/charts/theia-cloud-base/templates/clusterissuer-for-ca.yaml
@@ -1,7 +1,8 @@
+{{- if eq .Values.issuerca.useExisting false }}
 apiVersion: cert-manager.io/v1
 kind: ClusterIssuer
 metadata:
   name: {{ .Values.issuerca.name }}
 spec:
   selfSigned: {}
-  
+{{- end }}

--- a/charts/theia-cloud-base/templates/clusterissuer-production.yaml
+++ b/charts/theia-cloud-base/templates/clusterissuer-production.yaml
@@ -1,3 +1,4 @@
+{{- if eq .Values.issuerprod.useExisting false }}
 apiVersion: cert-manager.io/v1
 kind: ClusterIssuer
 metadata:
@@ -12,4 +13,5 @@ spec:
     - http01: 
         ingress:
             class: nginx
+{{- end }}
             

--- a/charts/theia-cloud-base/templates/clusterissuer-production.yaml
+++ b/charts/theia-cloud-base/templates/clusterissuer-production.yaml
@@ -1,4 +1,4 @@
-{{- if eq .Values.issuerprod.useExisting false }}
+{{- if eq .Values.issuerprod.enable false }}
 apiVersion: cert-manager.io/v1
 kind: ClusterIssuer
 metadata:

--- a/charts/theia-cloud-base/templates/clusterissuer-production.yaml
+++ b/charts/theia-cloud-base/templates/clusterissuer-production.yaml
@@ -1,4 +1,4 @@
-{{- if eq .Values.issuerprod.enable false }}
+{{- if .Values.issuerprod.enable }}
 apiVersion: cert-manager.io/v1
 kind: ClusterIssuer
 metadata:

--- a/charts/theia-cloud-base/values.yaml
+++ b/charts/theia-cloud-base/values.yaml
@@ -1,8 +1,10 @@
 issuerca:
+  useExisting: false
   # -- name for the issuer preparing a self signed CA certificate
   name: theia-cloud-ca-certificate-signer
 
 issuerprod:
+  useExisting: false
   # -- name for the let's encrypt production cluster issuer
   name: letsencrypt-prod
 

--- a/charts/theia-cloud-base/values.yaml
+++ b/charts/theia-cloud-base/values.yaml
@@ -1,10 +1,10 @@
 issuerca:
-  useExisting: false
+  enable: false
   # -- name for the issuer preparing a self signed CA certificate
   name: theia-cloud-ca-certificate-signer
 
 issuerprod:
-  useExisting: false
+  enable: false
   # -- name for the let's encrypt production cluster issuer
   name: letsencrypt-prod
 

--- a/charts/theia-cloud-base/values.yaml
+++ b/charts/theia-cloud-base/values.yaml
@@ -1,10 +1,10 @@
 issuerca:
-  enable: false
+  enable: true
   # -- name for the issuer preparing a self signed CA certificate
   name: theia-cloud-ca-certificate-signer
 
 issuerprod:
-  enable: false
+  enable: true
   # -- name for the let's encrypt production cluster issuer
   name: letsencrypt-prod
 


### PR DESCRIPTION
Currently, the `theia.cloud-base` helmchart always installs three `ClusterIssuer`: `issuerca`, `issuerprod`, and `issuerstaging`. This might make sense for a testing environment or a cluster just serving Theia but might be unnecessary for those environments in which ClusterIssuers are already handled. 
According to @jfaltermeier it would be useful to opt-out of automatic installs of `issuerca`, `issuerprod`.  Fixes #50. 

My changes introduce two new `useExisting` values that disable the creation of new ClusterIssuer. `issuerstaging` is always created as required for testing. 